### PR TITLE
refactor(portal): source the portal app-shell chrome from settings instead of Wagtail

### DIFF
--- a/airavata-django-portal/django_airavata/apps/api/templatetags/portal_chrome.py
+++ b/airavata-django-portal/django_airavata/apps/api/templatetags/portal_chrome.py
@@ -1,0 +1,41 @@
+"""Template tags that render the portal app-shell ("chrome") from settings.
+
+These replace the Wagtail-backed ``navigation_tags`` used by ``base.html``,
+sourcing the favicon, header logo, title, and user-menu links from
+``settings.PORTAL_CHROME`` / ``settings.PORTAL_TITLE``. They must not import
+Wagtail. (The Wagtail CMS-page shell keeps its own ``navigation_tags`` until the
+CMS is extracted.)
+"""
+
+from django import template
+from django.conf import settings
+
+register = template.Library()
+
+
+def _chrome():
+    return getattr(settings, "PORTAL_CHROME", {}) or {}
+
+
+@register.inclusion_tag("portal_chrome/favicon.html")
+def portal_favicon():
+    return {"favicon_url": _chrome().get("favicon_url")}
+
+
+@register.inclusion_tag("portal_chrome/logo.html")
+def portal_logo():
+    chrome = _chrome()
+    return {
+        "logo_url": chrome.get("logo_url"),
+        "logo_background_color": chrome.get("logo_background_color"),
+    }
+
+
+@register.simple_tag
+def portal_title():
+    return _chrome().get("title") or getattr(settings, "PORTAL_TITLE", "")
+
+
+@register.inclusion_tag("portal_chrome/main_menu.html")
+def portal_main_menu():
+    return {"user_menu_links": _chrome().get("user_menu_links") or []}

--- a/airavata-django-portal/django_airavata/settings.py
+++ b/airavata-django-portal/django_airavata/settings.py
@@ -216,6 +216,25 @@ GATEWAY_USER_DATA_ARCHIVE_MINIMUM_ARCHIVE_SIZE_GB = 1
 # Legacy (PGA) Portal link - provide a link to the legacy portal
 PGA_URL = None
 
+# Portal title shown in the header and emails. Override in settings_local.py.
+PORTAL_TITLE = 'Airavata Django Portal'
+
+# Portal app-shell "chrome" (base.html): favicon, header logo, and user-menu
+# links. Previously sourced from Wagtail snippet models; now sourced from
+# settings so the app shell does not depend on Wagtail. Every key is optional;
+# override PORTAL_CHROME (and PORTAL_TITLE) in settings_local.py.
+PORTAL_CHROME = {
+    # Favicon URL (absolute or static). Falls back to the bundled Airavata logo.
+    "favicon_url": None,
+    # Header logo image URL. Falls back to the bundled Airavata logo.
+    "logo_url": None,
+    # Optional background color for the header logo container.
+    "logo_background_color": None,
+    # Extra dropdown items in the user menu. List of
+    # {"link": str, "link_text": str, "icon_class": str}.
+    "user_menu_links": [],
+}
+
 # Django REST Framework configuration
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (

--- a/airavata-django-portal/django_airavata/templates/base.html
+++ b/airavata-django-portal/django_airavata/templates/base.html
@@ -1,10 +1,10 @@
-{% load navigation_tags static %}
+{% load portal_chrome static %}
 {% load render_bundle from webpack_loader %}
 {% load humanize %}
 <!DOCTYPE html>
 
 <head>
-  {% favicon %}
+  {% portal_favicon %}
   {% include "./django_airavata/google_analytics.html" %}
 
   {% render_bundle 'chunk-vendors' 'css' 'COMMON' %}
@@ -148,9 +148,9 @@
 <body>
   <header class=c-header>
     {% block header %}
-    {% gateway_icon %}
+    {% portal_logo %}
     {% endblock %}
-    <div class=c-header__title><a href="/">{% block title %}{% gateway_title %}{% endblock %}</a>
+    <div class=c-header__title><a href="/">{% block title %}{% portal_title %}{% endblock %}</a>
     </div>
     {% if user.is_authenticated %}
     <div class=c-header__controls>
@@ -195,7 +195,7 @@
                 {% endif %}
               {% endfor %}
             {% endif %}
-            {% main_menu_navs %}
+            {% portal_main_menu %}
           </div>
         </div>
       </div>

--- a/airavata-django-portal/django_airavata/templates/portal_chrome/favicon.html
+++ b/airavata-django-portal/django_airavata/templates/portal_chrome/favicon.html
@@ -1,0 +1,6 @@
+{% load static %}
+{% if favicon_url %}
+<link rel="icon" href="{{ favicon_url }}">
+{% else %}
+<link rel="icon" href="{% static 'images/airavata-logo.png' %}">
+{% endif %}

--- a/airavata-django-portal/django_airavata/templates/portal_chrome/logo.html
+++ b/airavata-django-portal/django_airavata/templates/portal_chrome/logo.html
@@ -1,0 +1,14 @@
+{% load static %}
+{% if logo_url %}
+<div class=c-header__logo{% if logo_background_color %} style="background-color: {{ logo_background_color }}"{% endif %}>
+    <a href="/">
+        <img src="{{ logo_url }}" />
+    </a>
+</div>
+{% else %}
+<div class=c-header__logo>
+    <a href="/">
+        <img src="{% static 'images/airavata-logo.png' %}" />
+    </a>
+</div>
+{% endif %}

--- a/airavata-django-portal/django_airavata/templates/portal_chrome/main_menu.html
+++ b/airavata-django-portal/django_airavata/templates/portal_chrome/main_menu.html
@@ -1,0 +1,8 @@
+{% for nav_item in user_menu_links %}
+  {% if forloop.first %}
+  <div class="dropdown-divider"></div>
+  {% endif %}
+  <a class="dropdown-item" href="{{ nav_item.link }}">
+    <i class="fa {{ nav_item.icon_class|default:'fa-link' }} mr-2"></i>{{ nav_item.link_text }}
+  </a>
+{% endfor %}


### PR DESCRIPTION
First step of extracting Wagtail out of the portal: decouple the portal **app shell** from Wagtail so it can later move to a standalone CMS.

`base.html` (the app shell) previously queried Wagtail snippet models (`GatewayIcon`, `GatewayTitle`, `NavExtra`) for the favicon, header logo, title, and user-menu dropdown links, so every portal page hard-depended on Wagtail being installed and populated. This introduces a Wagtail-free **`portal_chrome`** template-tag library (`django_airavata/apps/api/templatetags/portal_chrome.py`) that sources those from a small `PORTAL_CHROME` settings dict (empty-safe defaults, overridable in `settings_local.py`), plus three plain-Django include templates that preserve the original HTML/CSS classes. Only `base.html` is repointed.

Scope is deliberately limited to the app shell — the Wagtail `navigation_tags` library and the **CMS-page shell** (the `head`/`header`/`footer`/`nav-extra` includes, used only by the Wagtail page templates and rendering the page-tree menu) are left untouched and keep working until the CMS itself is extracted in a later step.

Validated on a local dev baseline (Python 3.10): `manage.py check` is green and `base.html` renders without Wagtail. +93/-5 across 7 files.