### PR TITLE
chore(portal): upgrade Django 3.2 → 5.2 LTS and DRF 3.12 → 3.16

### DIFF
--- a/airavata-django-portal/django_airavata/apps/api/apps.py
+++ b/airavata-django-portal/django_airavata/apps/api/apps.py
@@ -1,5 +1,6 @@
+from importlib.metadata import entry_points
+
 from django.apps import AppConfig
-from pkg_resources import iter_entry_points
 
 
 class ApiConfig(AppConfig):
@@ -11,5 +12,5 @@ class ApiConfig(AppConfig):
         from . import output_views
 
         # Load and create instances of each output view provider
-        for entry_point in iter_entry_points(group='airavata.output_view_providers'):
+        for entry_point in entry_points(group='airavata.output_view_providers'):
             output_views.OUTPUT_VIEW_PROVIDERS[entry_point.name] = entry_point.load()()

--- a/airavata-django-portal/django_airavata/settings.py
+++ b/airavata-django-portal/django_airavata/settings.py
@@ -145,8 +145,6 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 

--- a/airavata-django-portal/requirements.txt
+++ b/airavata-django-portal/requirements.txt
@@ -1,10 +1,10 @@
 # Pin these dependencies
-Django==3.2.18
+Django==5.2.15
 requests==2.25.1
 requests-oauthlib==0.7.0
 thrift==0.22.0
 thrift_connector==0.24
-djangorestframework==3.12.4
+djangorestframework==3.16.1
 django-webpack-loader==0.6.0
 logging-formatter-anticrlf==1.2
 zipstream-new==1.1.8


### PR DESCRIPTION
## Track B (start) — Django 3.2 → 5.2 LTS

Move the portal off **EOL Django 3.2** to the **5.2 LTS** line (runs on Python 3.10–3.13). With Wagtail removed (#115), the deprecation surface is tiny:

- **requirements** — `Django 3.2.18 → 5.2.15`, `djangorestframework 3.12.4 → 3.16.1`.
- **`settings.py`** — drop `USE_L10N` (removed in Django 5.0; localization is on by default).
- **`apps/api/apps.py`** — replace `pkg_resources.iter_entry_points` (removed in setuptools 81) with the stdlib `importlib.metadata.entry_points` selectable API (Python 3.10+). Clears the only remaining deprecation warning and the `setuptools<81` pin.

No other removed-API usage: `timezone.utc` is `datetime`'s (not the Django one removed in 5.0), and the `django.conf.urls.include` imports are still valid.

### Validation
On the baseline venv: **`manage.py check`** and **`makemigrations --check --dry-run`** are both clean on Django 5.2 (zero warnings). Full request-path validation needs the running backend (Track D / tilt); `check` exercises URLconf + app imports.

### Follow-ups (later Track B/C increments)
- `requests` / `requests-oauthlib` security bumps (oauthlib changes the auth flow — validated separately).
- `django-webpack-loader 0.6 → 3.x` — config-format change; `0.6.0` loads fine on 5.2, but its bump is validated together with the **Track C** frontend (Vite) build.
- Python 3.13 runtime switch.