### PR TITLE
Bump cryptography from 38.0.4 to 46.0.7 in airavata-django-portal-sdk

### DIFF
--- a/airavata-django-portal-sdk/requirements.txt
+++ b/airavata-django-portal-sdk/requirements.txt
@@ -1,7 +1,7 @@
 airavata-python-sdk==2.2.7
 bcrypt==3.1.7
 cffi==1.15.1
-cryptography==38.0.4
+cryptography==46.0.7
 Django==3.2.16
 djangorestframework==3.11.2
 google-api-python-client==1.12.8


### PR DESCRIPTION
Bumps `cryptography` from 38.0.4 to 46.0.7 in `airavata-django-portal-sdk/requirements.txt`, addressing dependabot PR #97. The SDK does not directly import `cryptography` (verified via source grep); it is consumed transitively by `paramiko`, `bcrypt`, and `PyNaCl`. Verified in a fresh Python 3.9 venv: `pip install -e .` with the updated requirement installs cleanly, all SDK modules (`util`, `views`, `serializers`, `decorators`, `user_storage`) import without error, and all 21 pytest tests pass (`21 passed in 0.15s`).