### PR TITLE
Bump flask-cors from 4.0.0 to 6.0.0 in airavata-mcp-client-chatbot/backend

### DIFF
--- a/airavata-mcp-client-chatbot/backend/requirements.txt
+++ b/airavata-mcp-client-chatbot/backend/requirements.txt
@@ -1,6 +1,6 @@
 # Flask Backend Dependencies
 flask==2.3.3
-flask-cors==4.0.0
+flask-cors==6.0.0
 
 # HTTP client for API calls
 requests==2.32.4


### PR DESCRIPTION
Bumps `flask-cors` from 4.0.0 to 6.0.0 in `airavata-mcp-client-chatbot/backend`. The v5/v6 releases tightened default CORS resource/origin handling; the existing bare `CORS(app)` call in `app.py` is compatible with the new defaults. Built and verified: fresh Python 3.10 venv, `pip install -r requirements.txt` resolves cleanly, and `from flask_cors import CORS; CORS(Flask(__name__))` imports and initialises without errors. Closes dependabot PR #39.