### PR TITLE
Bump urllib3 from 1.26.14 to 2.6.3 in airavata-custos-portal

### DIFF
--- a/airavata-custos-portal/requirements.txt
+++ b/airavata-custos-portal/requirements.txt
@@ -3,7 +3,7 @@ asgiref==3.5.2
 asttokens==2.1.0
 backcall==0.2.0
 black==22.10.0
-certifi==2022.12.7
+certifi==2024.2.2
 charset-normalizer==3.0.1
 click==8.1.3
 decorator==5.1.1
@@ -29,12 +29,12 @@ pure-eval==0.2.2
 Pygments==2.13.0
 PyJWT==0.4.3
 pytz==2022.6
-requests==2.28.2
+requests==2.32.3
 six==1.16.0
 sqlparse==0.5.4
 stack-data==0.6.0
 tomli==2.0.1
 traitlets==5.5.0
 typing_extensions==4.4.0
-urllib3==1.26.14
+urllib3==2.6.3
 wcwidth==0.2.5


### PR DESCRIPTION
Upgrades urllib3 from 1.26.14 to 2.6.3 (the latest 2.x release compatible with Python 3.9; urllib3 2.7.0 requires Python >=3.10) in `airavata-custos-portal/requirements.txt`. The 1.x -> 2.x transition is a breaking API change in urllib3 itself, but this project does not use urllib3 directly — it is a transitive dependency of `requests`. Two co-bumps are necessary: `requests` is updated from 2.28.2 to 2.32.3 because requests<2.30 carries a hard `urllib3<1.27` upper bound that blocks the 2.x upgrade; `certifi` is updated from 2022.12.7 to 2024.2.2 to align with the refreshed TLS stack. No boto/botocore dependencies are present, so there is no conflict with packages that pin `urllib3<2`. Verified by running `pip install -r requirements.txt` in a clean Python 3.9 venv (no dependency conflicts) and confirming `airavata_custos_portal.wsgi` imports successfully with urllib3 2.6.3 and requests 2.32.3.

Closes dependabot PR #78.