### PR TITLE
chore(deps): upgrade airavata-mft-portal Python dependencies (Django 3→4.2 LTS)

### DIFF
--- a/airavata-mft-portal/airavata_mft/apps/workspace/apps.py
+++ b/airavata-mft-portal/airavata_mft/apps/workspace/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class WorkspaceConfig(AppConfig):
-    name = 'workspace'
+    name = 'airavata_mft.apps.workspace'

--- a/airavata-mft-portal/airavata_mft/apps/workspace/urls.py
+++ b/airavata-mft-portal/airavata_mft/apps/workspace/urls.py
@@ -1,8 +1,8 @@
 from . import views
-from django.conf.urls import url
+from django.urls import re_path
 
 app_name='workspace'
 urlpatterns = [
-    url(r'^storage/$', views.storage,name="storages"),
-    url(r'^storage/(?P<storage_id>[^/]+)/$', views.resources,name="resources")
+    re_path(r'^storage/$', views.storage, name="storages"),
+    re_path(r'^storage/(?P<storage_id>[^/]+)/$', views.resources, name="resources")
 ]

--- a/airavata-mft-portal/airavata_mft/settings.py
+++ b/airavata-mft-portal/airavata_mft/settings.py
@@ -115,6 +115,7 @@ USE_L10N = True
 
 USE_TZ = True
 
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/

--- a/airavata-mft-portal/airavata_mft/urls.py
+++ b/airavata-mft-portal/airavata_mft/urls.py
@@ -14,10 +14,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import include
-from django.conf.urls import url
+from django.urls import include, re_path
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^workspace/', include('airavata_mft.apps.workspace.urls'))
+    re_path(r'^admin/', admin.site.urls),
+    re_path(r'^workspace/', include('airavata_mft.apps.workspace.urls'))
 ]

--- a/airavata-mft-portal/requirements.txt
+++ b/airavata-mft-portal/requirements.txt
@@ -1,5 +1,5 @@
-Django==3.0.4
-djangorestframework==3.11.0
-grpcio==1.27.2
-googleapis-common-protos==1.51.0
-django-webpack-loader==0.7.0
+Django==4.2.30
+djangorestframework==3.16.1
+grpcio==1.80.0
+googleapis-common-protos==1.75.0
+django-webpack-loader==1.8.1


### PR DESCRIPTION
Upgrades all Python dependencies in `airavata-mft-portal/requirements.txt` to current stable releases: Django 3.0.4 → 4.2.30 LTS, djangorestframework 3.11.0 → 3.16.1, grpcio 1.27.2 → 1.80.0 (1.27.2 has no binary wheels for Python 3.9+/arm64), googleapis-common-protos 1.51.0 → 1.75.0 (1.51.0 similarly unavailable), and django-webpack-loader 0.7.0 → 1.8.1. Three minimal code fixes were required for Django 4.x compatibility: (1) `django.conf.urls.url` (removed in Django 4.0) replaced with `django.urls.re_path` in both `urls.py` files, (2) `WorkspaceConfig.name` corrected from `'workspace'` to its full dotted path `'airavata_mft.apps.workspace'` as now strictly enforced by Django 4.2, and (3) `DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'` added to settings to silence the auto-primary-key system warning introduced in Django 3.2. Verified: fresh venv, `pip install --only-binary=:all: -r requirements.txt` succeeded, and `python manage.py check` reported "System check identified no issues (0 silenced)".