### PR TITLE
Bump langchain stack from 0.1.x/0.0.x to 0.3.x in airavata-mcp-client-chatbot/backend

### DIFF
--- a/airavata-mcp-client-chatbot/backend/requirements.txt
+++ b/airavata-mcp-client-chatbot/backend/requirements.txt
@@ -6,24 +6,24 @@ flask-cors==6.0.0
 requests==2.32.4
 
 # LangChain + Qwen3 integration (from your working demo)
-langchain==0.1.0
-langchain-community==0.0.13
-langchain-ollama==0.0.1
-langchain-core==0.1.0
+langchain==0.3.30
+langchain-community==0.3.27
+langchain-ollama==0.3.3
+langchain-core==0.3.86
 
 # FastAPI (alternative server option)
 fastapi==0.104.1
 uvicorn[standard]==0.24.0
 
 # Core dependencies
-pydantic==2.5.0
+pydantic>=2.7.0
 python-multipart==0.0.22
 python-dateutil==2.8.2
 
 # Development dependencies
 pytest==7.4.3
 pytest-asyncio==0.21.1
-httpx==0.25.2
+httpx>=0.27.0
 
 # Environment management
 python-dotenv==1.0.0


### PR DESCRIPTION
Coordinates a version-coupled upgrade of all four LangChain packages in `airavata-mcp-client-chatbot/backend/requirements.txt`: langchain 0.1.0→0.3.30, langchain-community 0.0.13→0.3.27, langchain-core 0.1.0→0.3.86, and langchain-ollama 0.0.1→0.3.3 (the 0.0.1 pin referenced in the original file was never published to PyPI, making the previous requirements.txt unresolvable). Also relaxes pydantic (pin 2.5.0→>=2.7.0) and httpx (pin 0.25.2→>=0.27.0) to satisfy langchain 0.3.x transitive constraints. All symbols used in this backend (`initialize_agent`, `AgentType`, `langchain.tools.tool`, `langchain_community.llms.Ollama`, `langchain_ollama.OllamaLLM`) remain present in the 0.3.x series. Verified: fresh Python 3.10 venv, `pip install -r requirements.txt` resolves cleanly with no conflicts, and all module-level imports succeed. Closes dependabot PRs #40 (langchain), #50 (langchain-community), #98 (langchain-core).