### PR TITLE
Bump pexpect, requests, and six in airavata-custos-portal

### DIFF
--- a/airavata-custos-portal/requirements.txt
+++ b/airavata-custos-portal/requirements.txt
@@ -20,7 +20,7 @@ matplotlib-inline==0.1.6
 mypy-extensions==0.4.3
 parso==0.8.3
 pathspec==0.10.1
-pexpect==4.8.0
+pexpect==4.9.0
 pickleshare==0.7.5
 platformdirs==2.5.2
 prompt-toolkit==3.0.32
@@ -29,8 +29,8 @@ pure-eval==0.2.2
 Pygments==2.13.0
 PyJWT==0.4.3
 pytz==2022.6
-requests==2.32.3
-six==1.16.0
+requests==2.32.5
+six==1.17.0
 sqlparse==0.5.4
 stack-data==0.6.0
 tomli==2.0.1


### PR DESCRIPTION
Patch-level bumps for three dependencies in `airavata-custos-portal/requirements.txt`: pexpect 4.8.0->4.9.0, requests 2.32.3->2.32.5, six 1.16.0->1.17.0. All three are backward-compatible maintenance releases with no API changes. Verified by running `pip install -r requirements.txt` in a clean Python 3.9 venv (no dependency conflicts) and confirming `airavata_custos_portal.wsgi` imports successfully.