### PR TITLE
Bump flask-cors from 6.0.0 to 6.0.4 in airavata-mcp-client-chatbot/backend

### DIFF
--- a/airavata-mcp-client-chatbot/backend/requirements.txt
+++ b/airavata-mcp-client-chatbot/backend/requirements.txt
@@ -1,6 +1,6 @@
 # Flask Backend Dependencies
 flask==2.3.3
-flask-cors==6.0.0
+flask-cors==6.0.4
 
 # HTTP client for API calls
 requests==2.32.4


### PR DESCRIPTION
Picks up micro-patch releases 6.0.1–6.0.4 of flask-cors, following the 4.0.0→6.0.0 bump merged in #131. Verified: fresh Python 3.10 venv, `pip install -r requirements.txt` resolves cleanly alongside the langchain 0.3.x stack, and flask-cors imports and initialises without errors.