### PR TITLE
Bump Jinja2 from 3.0.3 to 3.1.6 in airavata-django-portal-sdk

### DIFF
--- a/airavata-django-portal-sdk/requirements-dev.txt
+++ b/airavata-django-portal-sdk/requirements-dev.txt
@@ -7,7 +7,7 @@ Markdown==3.3.4 ; python_version < "3.7"
 mkdocs==1.3.0
 mkautodoc==0.2.0
 pycodestyle==2.6.0
-Jinja2==3.0.3
+Jinja2==3.1.6
 pytest==7.0.1
 pytest-django==4.5.2
 tox==3.27.1


### PR DESCRIPTION
Bumps `Jinja2` from 3.0.3 to 3.1.6 in `airavata-django-portal-sdk/requirements-dev.txt`, addressing dependabot PR #129. Jinja2 is a development/docs dependency consumed transitively by `mkdocs`; the SDK source does not import it directly (verified via grep). Verified in a fresh Python 3.9 venv: `pip install -e .` with the updated requirement installs cleanly, Jinja2 3.1.6 imports and renders a template correctly, `mkdocs==1.3.0` (the Jinja2 consumer) imports cleanly alongside it, all SDK modules import without error, and all 21 pytest tests pass (`21 passed in 0.13s`).