### PR TITLE
build(local-agent): upgrade electron 29->39

### DIFF
--- a/airavata-local-agent/main/background.js
+++ b/airavata-local-agent/main/background.js
@@ -127,9 +127,9 @@ if (!gotTheLock) {
 
     app.commandLine.appendSwitch('ignore-certificate-errors');
 
-    session.defaultSession.clearStorageData([], (data) => {
-      log.info("Cleared storage data", data);
-    });
+    session.defaultSession.clearStorageData()
+      .then(() => log.info("Cleared storage data"))
+      .catch((err) => log.error("Error clearing storage data", err));
 
     mainWindow.webContents.setWindowOpenHandler(({ url }) => {
       // open external URLs in browser, not in the app
@@ -194,9 +194,9 @@ ipcMain.on('open-default-browser', (event, url) => {
 
 ipcMain.on('ci-logon-logout', (event) => {
   log.warn('logging out');
-  session.defaultSession.clearStorageData([], (data) => {
-    log.info("Cleared storage data", data);
-  });
+  session.defaultSession.clearStorageData()
+    .then(() => log.info("Cleared storage data"))
+    .catch((err) => log.error("Error clearing storage data", err));
 });
 
 ipcMain.on('ci-logon-login', async (event) => {

--- a/airavata-local-agent/package-lock.json
+++ b/airavata-local-agent/package-lock.json
@@ -34,7 +34,7 @@
       },
       "devDependencies": {
         "@electron/fuses": "^1.8.0",
-        "electron": "^29.3.0",
+        "electron": "^39.0.0",
         "electron-builder": "^26.0.0",
         "next": "^15.5.19",
         "nextron": "^9.6.0",
@@ -5712,11 +5712,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.12.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
-      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/node-forge": {
@@ -10135,14 +10136,15 @@
       }
     },
     "node_modules/electron": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-29.4.1.tgz",
-      "integrity": "sha512-YQvMAtdmjMF1yGfQFuO/KOmy+04SKot85NalppK/8zxKwOKrrK6dJBp+nJWteqBwRAKiasSrC1lDalF6hZct/w==",
+      "version": "39.8.10",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.10.tgz",
+      "integrity": "sha512-zbYtGPYUI7PzqLAzkk21Rk6j67WN0hxn0Mq/njErZo1d0HSf33is4f8ICI5fMLy5vYe0JtCtM5sYunNOaochSQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^20.9.0",
+        "@types/node": "^22.7.7",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -23149,9 +23151,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/airavata-local-agent/package.json
+++ b/airavata-local-agent/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@electron/fuses": "^1.8.0",
-    "electron": "^29.3.0",
+    "electron": "^39.0.0",
     "electron-builder": "^26.0.0",
     "next": "^15.5.19",
     "nextron": "^9.6.0",


### PR DESCRIPTION
Upgrades `electron` in airavata-local-agent from `^29.3.0` to `^39.0.0` (resolves to 39.8.10), superseding dependabot #49.

**Code change:** the two `session.defaultSession.clearStorageData()` calls in `main/background.js` are migrated from the removed callback overload to the promise-based API (`.then()/.catch()`); the callback form no longer exists in modern Electron. No other main-process Electron API used by the app changed across 30..39.

**Built & verified (macOS arm64, Node 26, Electron 39.8.10):**
1. Clean `npm install` — `postinstall` (`electron-builder install-app-deps`) rebuilt native deps (cpu-features via @electron/rebuild) against `electronVersion=39.8.10 arch=arm64`; completed with no native build errors.
2. `CSC_IDENTITY_AUTO_DISCOVERY=false npm run build -- --mac --publish never` — `next build` exported 12 static pages, the main-process webpack bundle compiled, and electron-builder (v26.15.2) packaged a DMG + zip + `.app` (Electron Framework 39.8.10 embedded). Exit 0, no errors; `electron-builder.yml` needed no changes for v26.
3. Launch smoke: ran the packaged `.app` for ~20s under a timeout. The main process started, `app.whenReady()` fired ("App is now ready"), the migrated `clearStorageData()` promise resolved ("Cleared storage data"), and renderer→main IPC ran (gateways, version, docker-ping loop) with no crash before being killed.