### PR TITLE
fix(portal): load COMMON Vite ESM bundles as ES modules in base.html

### DIFF
--- a/airavata-django-portal/django_airavata/templates/base.html
+++ b/airavata-django-portal/django_airavata/templates/base.html
@@ -1,5 +1,5 @@
 {% load portal_chrome static %}
-{% load render_bundle from webpack_loader %}
+{% load render_bundle get_files from webpack_loader %}
 {% load humanize %}
 <!DOCTYPE html>
 
@@ -7,7 +7,6 @@
   {% portal_favicon %}
   {% include "./django_airavata/google_analytics.html" %}
 
-  {% render_bundle 'chunk-vendors' 'css' 'COMMON' %}
   {% render_bundle 'app' 'css' 'COMMON' %}
   {% block css %}
 
@@ -256,10 +255,16 @@
     // provide data for initializing api's session.Session
     window.AiravataPortalSessionData = {{ user_session_data|safe }};
   </script>
-  {% render_bundle 'chunk-vendors' 'js' 'COMMON' %}
-  {% render_bundle 'app' 'js' 'COMMON' %}
+  {% comment %} Vite emits ES module bundles; load them as type="module" so their
+  shared-chunk imports resolve. The inline session script above is a classic
+  script and runs first, before these deferred modules. {% endcomment %}
+  {% get_files 'app' 'js' 'COMMON' as common_app_js %}
+  {% for f in common_app_js %}<script type="module" src="{{ f.url }}"></script>
+  {% endfor %}
   {% if user.is_authenticated %}
-    {% render_bundle 'notices' 'js' 'COMMON' %}
+    {% get_files 'notices' 'js' 'COMMON' as common_notices_js %}
+    {% for f in common_notices_js %}<script type="module" src="{{ f.url }}"></script>
+    {% endfor %}
   {% endif %}
   {% block scripts %}
   {% endblock %}


### PR DESCRIPTION
## Summary
`static/common` migrated to Vite in #144, which emits **ES module** bundles (each entry statically imports a shared chunk, e.g. `_commonjsHelpers.js`). The root `templates/base.html` still:
- referenced the Vue-CLI `chunk-vendors` split bundle, which Vite does not produce → `render_bundle 'chunk-vendors' …` raises `WebpackBundleLookupError` on **every** page; and
- loaded the `app`/`notices` bundles as classic `<script type="text/javascript">`, which cannot execute ESM (`import` outside a module).

This loads the COMMON bundles via `get_files` + `<script type="module">` (URLs come from the same Vite-emitted `webpack-stats.json`, so the Django/webpack-loader config is otherwise unchanged) and drops the dead `chunk-vendors` lines. The inline `window.AiravataPortalSessionData` script remains a classic script and still runs before the deferred module bundles, so session init ordering is preserved.

## Test plan
- `templates/base.html` compiles via Django's template loader (all tags parse).
- `manage.py check` — no issues.
- Offline render against the committed Vite stats confirms `<script type="module" src="/static/common/dist/js/app.js"></script>` is emitted and the old `chunk-vendors` lookup raised before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)