### PR TITLE
feat(portal): repoint application module reads to gRPC (Track D, D2)

### DIFF
--- a/airavata-django-portal/django_airavata/apps/api/grpc_adapters.py
+++ b/airavata-django-portal/django_airavata/apps/api/grpc_adapters.py
@@ -28,3 +28,13 @@ def project(pb):
         sharedUsers=list(pb.shared_users),
         sharedGroups=list(pb.shared_groups),
     )
+
+
+def application_module(pb):
+    """gRPC ``ApplicationModule`` protobuf -> ``ApplicationModuleSerializer`` shape."""
+    return SimpleNamespace(
+        appModuleId=pb.app_module_id,
+        appModuleName=pb.app_module_name,
+        appModuleVersion=pb.app_module_version,
+        appModuleDescription=pb.app_module_description,
+    )

--- a/airavata-django-portal/django_airavata/apps/api/views.py
+++ b/airavata-django-portal/django_airavata/apps/api/views.py
@@ -439,12 +439,15 @@ class ApplicationModuleViewSet(APIBackedViewSet):
     lookup_field = 'app_module_id'
 
     def get_list(self):
-        return self.request.airavata_client.getAccessibleAppModules(
-            self.authz_token, self.gateway_id)
+        return [
+            grpc_adapters.application_module(m)
+            for m in self.request.airavata.research.get_accessible_app_modules(
+                gateway_id=self.gateway_id)
+        ]
 
     def get_instance(self, lookup_value):
-        return self.request.airavata_client.getApplicationModule(
-            self.authz_token, lookup_value)
+        return grpc_adapters.application_module(
+            self.request.airavata.research.get_application_module(lookup_value))
 
     def perform_create(self, serializer):
         app_module = serializer.save()
@@ -535,8 +538,11 @@ class ApplicationModuleViewSet(APIBackedViewSet):
 
     @action(detail=False)
     def list_all(self, request, format=None):
-        all_modules = self.request.airavata_client.getAllAppModules(
-            self.authz_token, self.gateway_id)
+        all_modules = [
+            grpc_adapters.application_module(m)
+            for m in self.request.airavata.research.get_all_app_modules(
+                gateway_id=self.gateway_id)
+        ]
         serializer = self.serializer_class(
             all_modules, many=True, context={'request': request})
         return Response(serializer.data)


### PR DESCRIPTION
## Summary
Continues Track D D2 — migrates the **application module** read paths off Thrift onto the gRPC facade, using the pattern established in #158.

- `ApplicationModuleViewSet` reads — `get_list` → `research.get_accessible_app_modules`, `get_instance` → `research.get_application_module`, `list_all` → `research.get_all_app_modules`. Writes (create/update/destroy) and the `application_interface`/`application_deployments` actions stay on Thrift (they belong to the interface/deployment families).
- `grpc_adapters.application_module()` maps the `ApplicationModule` protobuf (`app_module_id`, …) to the Thrift attribute names `ApplicationModuleSerializer` reads (`appModuleId`, …) — REST contract unchanged, serializer reused.

## Test plan
- Structural: a real `ApplicationModule` protobuf through `grpc_adapters.application_module()` exposes all 4 Thrift fields with correct values.
- `manage.py check` — no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)