### PR TITLE
feat(portal): migrate project userHasWriteAccess to gRPC sharing (Track D)

### DIFF
--- a/airavata-django-portal/django_airavata/apps/api/serializers.py
+++ b/airavata-django-portal/django_airavata/apps/api/serializers.py
@@ -80,6 +80,20 @@ from . import models, thrift_utils, view_utils
 log = logging.getLogger(__name__)
 
 
+def user_has_access(request, resource_id, permission="WRITE"):
+    """gRPC sharing access check (Track D — replaces the Thrift userHasAccess).
+
+    ``permission`` is the ResourcePermissionType enum name (WRITE/READ/OWNER/
+    MANAGE_SHARING); the backend prefixes the gateway internally. The acting user
+    is taken from the authenticated token context server-side, so ``user_id`` is
+    passed for the facade signature but ignored by the backend.
+    """
+    return request.airavata.sharing.user_has_access(
+        resource_id=resource_id,
+        user_id=request.user.username,
+        permission_type=permission)
+
+
 class FullyEncodedHyperlinkedIdentityField(
         serializers.HyperlinkedIdentityField):
     def get_url(self, obj, view_name, request, format):
@@ -282,10 +296,7 @@ class ProjectSerializer(
         return instance
 
     def get_userHasWriteAccess(self, project):
-        request = self.context['request']
-        return request.airavata_client.userHasAccess(
-            request.authz_token, project.projectID,
-            ResourcePermissionType.WRITE)
+        return user_has_access(self.context['request'], project.projectID)
 
     def get_isOwner(self, project):
         request = self.context['request']


### PR DESCRIPTION
## Summary
Completes the de-Thrift of the **projects** read path — `ProjectSerializer.userHasWriteAccess` now uses the gRPC **sharing** facade instead of Thrift `request.airavata_client.userHasAccess`. Adds a reusable `serializers.user_has_access(request, resource_id, permission)` helper for the remaining families.

## Format confirmed from the backend impl + runtime-validated
`SharingGrpcService.userHasAccess`: `permission_type` is the **ResourcePermissionType enum name** (`WRITE`/`READ`/`MANAGE_SHARING`) — the backend adds the gateway prefix internally — and the acting user comes from the **authenticated token context** server-side (the `user_id` field is passed for the facade signature but ignored). An initial `gatewayId:WRITE` guess was rejected (`No enum constant ...ResourcePermissionType`); the corrected call `user_has_access(resource_id, 'WRITE')` returns **True** for the owner against the live backend.

## Test plan
- `manage.py check` — no issues.
- Runtime: seeded a project via the facade, `sharing.user_has_access(pid, 'WRITE')` → `True`; cleaned up.
- The migrated `/api/projects/` returns 200 (empty path validated earlier; serializer sub-call now also gRPC).

Note: other serializers' `userHasWriteAccess` (experiments, deployments, credentials, GRPs) migrate with their read families; the `is_gateway_admin`-based ones need admin derived from the token under pure-token auth (separate D5 piece).

🤖 Generated with [Claude Code](https://claude.com/claude-code)