### PR TITLE
fix(portal): default is_gateway_admin under pure-token auth (Track D)

### DIFF
--- a/airavata-django-portal/django_airavata/apps/auth/token_authentication.py
+++ b/airavata-django-portal/django_airavata/apps/auth/token_authentication.py
@@ -89,6 +89,17 @@ class KeycloakTokenAuthentication(authentication.BaseAuthentication):
         if hasattr(request, '_request'):
             request._request.authz_token = authz_token
             request._request.user = user
+        # Several serializers read request.is_gateway_admin (it was set by the
+        # session-based gateway_groups_middleware, which pure-token auth skips).
+        # Default to non-admin so those serializers don't crash. TODO (D5): derive
+        # real admin status from gRPC — compute.get_gateway_groups() +
+        # sharing.gm_get_all_groups_user_belongs(username) — once there is an admin
+        # gateway user to validate the group/field shapes against, and cache it.
+        request.is_gateway_admin = False
+        request.is_read_only_gateway_admin = False
+        if hasattr(request, '_request'):
+            request._request.is_gateway_admin = False
+            request._request.is_read_only_gateway_admin = False
         return (user, token)
 
     def authenticate_header(self, request):


### PR DESCRIPTION
## Summary
Pure-token auth (#160) skips the session-based `gateway_groups_middleware` that set `request.is_gateway_admin` / `is_read_only_gateway_admin`. Several serializers read those (app modules, app interfaces, gateway resource profiles, user profiles) for `userHasWriteAccess`, so they would raise `AttributeError` once a request returns data. This defaults them to non-admin in `KeycloakTokenAuthentication`.

Real admin derivation (gRPC `compute.get_gateway_groups()` + `sharing.gm_get_all_groups_user_belongs(username)`, cached) is **deferred** until there's an admin gateway user to validate the group/field shapes against — same lesson as the sharing `permission_type` (don't ship unvalidated proto-field assumptions).

## Test plan
- `manage.py check` — no issues.
- `/api/applications/` and `/api/projects/` continue to return 200 (validated against the running backend with a Bearer token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)