### PR TITLE
feat(portal): repoint experiment search to gRPC (Track D, D2)

### DIFF
--- a/airavata-django-portal/django_airavata/apps/api/grpc_adapters.py
+++ b/airavata-django-portal/django_airavata/apps/api/grpc_adapters.py
@@ -38,3 +38,20 @@ def application_module(pb):
         appModuleVersion=pb.app_module_version,
         appModuleDescription=pb.app_module_description,
     )
+
+
+def experiment_summary(pb):
+    """gRPC ``ExperimentSummaryModel`` protobuf -> ``ExperimentSummarySerializer`` shape."""
+    return SimpleNamespace(
+        experimentId=pb.experiment_id,
+        projectId=pb.project_id,
+        gatewayId=pb.gateway_id,
+        creationTime=pb.creation_time or None,
+        userName=pb.user_name,
+        name=pb.name,
+        description=pb.description,
+        executionId=pb.execution_id,
+        resourceHostId=pb.resource_host_id,
+        experimentStatus=pb.experiment_status,
+        statusUpdateTime=pb.status_update_time or None,
+    )

--- a/airavata-django-portal/django_airavata/apps/api/serializers.py
+++ b/airavata-django-portal/django_airavata/apps/api/serializers.py
@@ -734,10 +734,7 @@ class ExperimentSummarySerializer(BaseExperimentSummarySerializer):
     userHasWriteAccess = serializers.SerializerMethodField()
 
     def get_userHasWriteAccess(self, experiment):
-        request = self.context['request']
-        return request.airavata_client.userHasAccess(
-            request.authz_token, experiment.experimentId,
-            ResourcePermissionType.WRITE)
+        return user_has_access(self.context['request'], experiment.experimentId)
 
 
 class UserProfileSerializer(

--- a/airavata-django-portal/django_airavata/apps/api/views.py
+++ b/airavata-django-portal/django_airavata/apps/api/views.py
@@ -315,18 +315,19 @@ class ExperimentSearchViewSet(mixins.ListModelMixin, GenericAPIBackedViewSet):
     def get_list(self):
         view = self
 
+        # gRPC SearchExperiments takes filters as a map<string, string> keyed by
+        # ExperimentSearchFields member name (the query-param key already is one).
         filters = {}
-        for filter_item in self.request.query_params.items():
-            if filter_item[0] in ExperimentSearchFields.__members__:
-                # Lookup enum value for this ExperimentSearchFields
-                search_field = ExperimentSearchFields[filter_item[0]]
-                filters[search_field] = filter_item[1]
+        for key, value in self.request.query_params.items():
+            if key in ExperimentSearchFields.__members__:
+                filters[key] = value
 
         class ExperimentSearchResultIterator(APIResultIterator):
             def get_results(self, limit=-1, offset=0):
-                return view.request.airavata_client.searchExperiments(
-                    view.authz_token, view.gateway_id, view.username, filters,
-                    limit, offset)
+                summaries = view.request.airavata.research.search_experiments(
+                    gateway_id=view.gateway_id, user_name=view.username,
+                    filters=filters, limit=limit, offset=offset)
+                return [grpc_adapters.experiment_summary(s) for s in summaries]
 
         # Preserve query parameters when moving to next and previous links
         return ExperimentSearchResultIterator(query_params=self.request.query_params.copy())


### PR DESCRIPTION
## Summary
Migrates the **experiment search** (the experiment list) off Thrift onto the gRPC facade.

- `ExperimentSearchViewSet.get_list` → `request.airavata.research.search_experiments`. Filters pass through as the gRPC `map<string,string>` keyed by `ExperimentSearchFields` member name (the query-param key already is one).
- `grpc_adapters.experiment_summary` maps `ExperimentSummaryModel` protobuf → the Thrift attribute shape (clean 1:1; `experiment_status` is a plain string in both Thrift and proto).
- `ExperimentSummarySerializer.userHasWriteAccess` → the gRPC `user_has_access` sharing helper.

## Validated end-to-end (running portal + Bearer token)
- `GET /api/experiment-search/` → **200** `{"results":[],...}`
- adapter: a real `ExperimentSummaryModel` protobuf exposes all 11 Thrift fields.
- the sibling `/api/projects/` returns a **real seeded project** with every field correct (timestamp, hyperlinks, `userHasWriteAccess:true` via gRPC sharing, `isOwner:true`), confirming the full read path with data.

(Validation needed registering the calling user via `iam.add_user_profile`, since user-scoped reads reject unknown users.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)