### PR TITLE
feat(portal): repoint application interface reads to gRPC (Track D, D2)

### DIFF
--- a/airavata-django-portal/django_airavata/apps/api/grpc_adapters.py
+++ b/airavata-django-portal/django_airavata/apps/api/grpc_adapters.py
@@ -13,6 +13,7 @@ serializers are made protobuf-native.
 
 from types import SimpleNamespace
 
+from airavata.model.application.io.ttypes import DataType as _ThriftDataType
 from airavata.model.credential.store.ttypes import SummaryType as _ThriftSummaryType
 
 
@@ -103,4 +104,63 @@ def credential_summary(pb):
         persistedTime=pb.persisted_time,
         token=pb.token,
         description=pb.description,
+    )
+
+
+def _input_data_object(pb):
+    """gRPC ``InputDataObjectType`` -> ``InputDataObjectTypeSerializer`` shape."""
+    return SimpleNamespace(
+        name=pb.name,
+        value=pb.value,
+        # DataType proto/Thrift ints differ per name -> bridge by name; the
+        # serializer's EnumChoiceField(DataType) reads ``.name`` off the member.
+        type=_thrift_enum(pb, 'type', _ThriftDataType),
+        applicationArgument=pb.application_argument,
+        standardInput=pb.standard_input,
+        userFriendlyDescription=pb.user_friendly_description,
+        # JSON string; empty -> None so StoredJSONField renders null like Thrift.
+        metaData=pb.meta_data or None,
+        inputOrder=pb.input_order,
+        isRequired=pb.is_required,
+        requiredToAddedToCommandLine=pb.required_to_added_to_command_line,
+        dataStaged=pb.data_staged,
+        storageResourceId=pb.storage_resource_id,
+        isReadOnly=pb.is_read_only,
+        overrideFilename=pb.override_filename,
+    )
+
+
+def _output_data_object(pb):
+    """gRPC ``OutputDataObjectType`` -> ``OutputDataObjectTypeSerializer`` shape."""
+    return SimpleNamespace(
+        name=pb.name,
+        value=pb.value,
+        type=_thrift_enum(pb, 'type', _ThriftDataType),
+        applicationArgument=pb.application_argument,
+        isRequired=pb.is_required,
+        requiredToAddedToCommandLine=pb.required_to_added_to_command_line,
+        dataMovement=pb.data_movement,
+        location=pb.location,
+        searchQuery=pb.search_query,
+        outputStreaming=pb.output_streaming,
+        storageResourceId=pb.storage_resource_id,
+        metaData=pb.meta_data or None,
+    )
+
+
+def application_interface(pb):
+    """gRPC ``ApplicationInterfaceDescription`` -> ``ApplicationInterfaceDescriptionSerializer`` shape.
+
+    Recursively adapts the nested ``applicationInputs``/``applicationOutputs``
+    repeated messages.
+    """
+    return SimpleNamespace(
+        applicationInterfaceId=pb.application_interface_id,
+        applicationName=pb.application_name,
+        applicationDescription=pb.application_description,
+        applicationModules=list(pb.application_modules),
+        applicationInputs=[_input_data_object(i) for i in pb.application_inputs],
+        applicationOutputs=[_output_data_object(o) for o in pb.application_outputs],
+        archiveWorkingDirectory=pb.archive_working_directory,
+        hasOptionalFileInputs=pb.has_optional_file_inputs,
     )

--- a/airavata-django-portal/django_airavata/apps/api/views.py
+++ b/airavata-django-portal/django_airavata/apps/api/views.py
@@ -554,18 +554,22 @@ class ApplicationInterfaceViewSet(APIBackedViewSet):
     lookup_field = 'app_interface_id'
 
     def get_list(self):
-        return self.request.airavata_client.getAllApplicationInterfaces(
-            self.authz_token, self.gateway_id)
+        return [
+            grpc_adapters.application_interface(i)
+            for i in self.request.airavata.research.get_all_application_interfaces(
+                self.gateway_id)
+        ]
 
     def get_instance(self, lookup_value):
         try:
-            return self.request.airavata_client.getApplicationInterface(
-                self.authz_token, lookup_value)
+            return grpc_adapters.application_interface(
+                self.request.airavata.research.get_application_interface(
+                    lookup_value))
         except Exception:
             # If it failed to load, check to see if it exists at all
-            all_interfaces = self.request.airavata_client.getAllApplicationInterfaces(
-                self.authz_token, self.gateway_id)
-            interface_ids = map(lambda i: i.applicationInterfaceId, all_interfaces)
+            all_interfaces = self.request.airavata.research.get_all_application_interfaces(
+                self.gateway_id)
+            interface_ids = [i.application_interface_id for i in all_interfaces]
             if lookup_value not in interface_ids:
                 raise Http404("Application interface does not exist")
             else:
@@ -608,8 +612,8 @@ class ApplicationInterfaceViewSet(APIBackedViewSet):
 
     @action(detail=True)
     def compute_resources(self, request, app_interface_id):
-        compute_resources = request.airavata_client.getAvailableAppInterfaceComputeResources(
-            self.authz_token, app_interface_id)
+        compute_resources = request.airavata.research.get_available_app_interface_compute_resources(
+            app_interface_id)
         return Response(compute_resources)
 
 


### PR DESCRIPTION
## Summary
Migrate `ApplicationInterfaceViewSet` reads from the Thrift client to the gRPC research facade — the first **nested** read family in Track D. Reuses the existing serializer via a recursive protobuf→Thrift-attribute adapter, so the portal's REST contract is unchanged.

- `get_list`, `get_instance`, and the `compute_resources` action now call `request.airavata.research.get_all_application_interfaces` / `get_application_interface` / `get_available_app_interface_compute_resources`.
- Write actions (register/update/delete) stay on Thrift pending D3.
- New `application_interface` adapter **recursively** adapts the repeated `applicationInputs` (`InputDataObjectType`) and `applicationOutputs` (`OutputDataObjectType`) sub-messages.
- **Enum-by-name bridge (reused helper):** `DataType` has the same proto/Thrift integer mismatch as `SummaryType` (proto `STRING=1` vs Thrift `STRING=0`), so the nested adapters convert it by NAME via `_thrift_enum` and the serializer's `EnumChoiceField(DataType)` labels it correctly.
- `metaData` (a JSON string) maps empty → `None` so `StoredJSONField` renders `null` exactly as it did on Thrift.
- `userHasWriteAccess` here is gateway-admin-based (not sharing) → unchanged.

## Test plan
- `manage.py check` clean.
- Empty list returns 200; a seeded interface round-trips (list + detail, 200) against the live backend.
- Offline serializer render with real **nested** protobuf confirms inputs/outputs adapt with all fields, `DataType` labels by name (URI/STDOUT), `metaData` parses to an object (input) / `null` (empty output), and `url`/`queueSettingsCalculatorId` match the prior contract.
- Note: the dev backend does not persist interface inputs/outputs/module links on registration, so nested live data was validated via the offline render against real protobuf rather than a live round-trip.