### PR TITLE
feat(portal): repoint application deployment reads to gRPC (Track D, D2)

### DIFF
--- a/airavata-django-portal/django_airavata/apps/api/grpc_adapters.py
+++ b/airavata-django-portal/django_airavata/apps/api/grpc_adapters.py
@@ -13,6 +13,9 @@ serializers are made protobuf-native.
 
 from types import SimpleNamespace
 
+from airavata.model.appcatalog.parallelism.ttypes import (
+    ApplicationParallelismType as _ThriftParallelismType,
+)
 from airavata.model.application.io.ttypes import DataType as _ThriftDataType
 from airavata.model.credential.store.ttypes import SummaryType as _ThriftSummaryType
 
@@ -163,4 +166,44 @@ def application_interface(pb):
         applicationOutputs=[_output_data_object(o) for o in pb.application_outputs],
         archiveWorkingDirectory=pb.archive_working_directory,
         hasOptionalFileInputs=pb.has_optional_file_inputs,
+    )
+
+
+def _command_object(pb):
+    """gRPC ``CommandObject`` -> ``CommandObjectSerializer`` shape."""
+    return SimpleNamespace(command=pb.command, commandOrder=pb.command_order)
+
+
+def _set_env_paths(pb):
+    """gRPC ``SetEnvPaths`` -> ``SetEnvPathsSerializer`` shape."""
+    return SimpleNamespace(
+        name=pb.name, value=pb.value, envPathOrder=pb.env_path_order)
+
+
+def application_deployment(pb):
+    """gRPC ``ApplicationDeploymentDescription`` -> ``ApplicationDeploymentDescriptionSerializer`` shape.
+
+    Recursively adapts the nested command/env-path lists. ``parallelism`` is an
+    enum with the proto/Thrift integer mismatch (proto SERIAL=1 vs Thrift
+    SERIAL=0) -> bridged by name. The queue-default cluster maps the proto-zero
+    "unset" sentinels back to None so the serializer renders null as Thrift did.
+    """
+    return SimpleNamespace(
+        appDeploymentId=pb.app_deployment_id,
+        appModuleId=pb.app_module_id,
+        computeHostId=pb.compute_host_id,
+        executablePath=pb.executable_path,
+        parallelism=_thrift_enum(pb, 'parallelism', _ThriftParallelismType),
+        appDeploymentDescription=pb.app_deployment_description,
+        moduleLoadCmds=[_command_object(c) for c in pb.module_load_cmds],
+        libPrependPaths=[_set_env_paths(p) for p in pb.lib_prepend_paths],
+        libAppendPaths=[_set_env_paths(p) for p in pb.lib_append_paths],
+        setEnvironment=[_set_env_paths(p) for p in pb.set_environment],
+        preJobCommands=[_command_object(c) for c in pb.pre_job_commands],
+        postJobCommands=[_command_object(c) for c in pb.post_job_commands],
+        defaultQueueName=pb.default_queue_name or None,
+        defaultNodeCount=pb.default_node_count or None,
+        defaultCPUCount=pb.default_cpu_count or None,
+        defaultWalltime=pb.default_walltime or None,
+        editableByUser=pb.editable_by_user,
     )

--- a/airavata-django-portal/django_airavata/apps/api/serializers.py
+++ b/airavata-django-portal/django_airavata/apps/api/serializers.py
@@ -515,10 +515,8 @@ class ApplicationDeploymentDescriptionSerializer(
         allow_null=True)
 
     def get_userHasWriteAccess(self, appDeployment):
-        request = self.context['request']
-        return request.airavata_client.userHasAccess(
-            request.authz_token, appDeployment.appDeploymentId,
-            ResourcePermissionType.WRITE)
+        return user_has_access(
+            self.context['request'], appDeployment.appDeploymentId)
 
 
 class ComputeResourceDescriptionSerializer(

--- a/airavata-django-portal/django_airavata/apps/api/views.py
+++ b/airavata-django-portal/django_airavata/apps/api/views.py
@@ -630,15 +630,16 @@ class ApplicationDeploymentViewSet(APIBackedViewSet):
             raise ParseError("Query params appModuleId and "
                              "groupResourceProfileId are required together.")
         if app_module_id and group_resource_profile_id:
-            return self.request.airavata_client.getApplicationDeploymentsForAppModuleAndGroupResourceProfile(
-                self.authz_token, app_module_id, group_resource_profile_id)
+            deployments = self.request.airavata.research.get_application_deployments_for_app_module_and_group_resource_profile(
+                app_module_id, group_resource_profile_id)
         else:
-            return self.request.airavata_client.getAccessibleApplicationDeployments(
-                self.authz_token, self.gateway_id, ResourcePermissionType.READ)
+            deployments = self.request.airavata.research.get_accessible_application_deployments(
+                self.gateway_id)
+        return [grpc_adapters.application_deployment(d) for d in deployments]
 
     def get_instance(self, lookup_value):
-        return self.request.airavata_client.getApplicationDeployment(
-            self.authz_token, lookup_value)
+        return grpc_adapters.application_deployment(
+            self.request.airavata.research.get_application_deployment(lookup_value))
 
     def perform_create(self, serializer):
         application_deployment = serializer.save()


### PR DESCRIPTION
## Summary
Migrate `ApplicationDeploymentViewSet` reads from the Thrift client to the gRPC research facade, continuing the Track D nested read-family repoint. Reuses the existing serializer via a recursive protobuf→Thrift-attribute adapter, so the portal's REST contract is unchanged.

- `get_list` (both the accessible path and the app-module + group-resource-profile path) and `get_instance` now call `request.airavata.research.get_accessible_application_deployments` / `get_application_deployments_for_app_module_and_group_resource_profile` / `get_application_deployment`.
- Write actions and the `queues` action stay on Thrift: `queues` reads a `ComputeResource`, so it moves with the compute-resources family.
- New `application_deployment` adapter **recursively** adapts the nested command lists (`moduleLoadCmds`/`preJobCommands`/`postJobCommands` → `CommandObject`) and env-path lists (`libPrependPaths`/`libAppendPaths`/`setEnvironment` → `SetEnvPaths`).
- **Enum-by-name bridge (critical here):** the serializer renders `parallelism` as a raw **integer** (the auto-generated field is an `IntegerField`, not a `ThriftEnumField`), and proto/Thrift `ApplicationParallelismType` integers differ per name (proto `SERIAL=1` vs Thrift `SERIAL=0`). The adapter bridges by NAME via `_thrift_enum` to emit the Thrift integer the frontend expects — passing the raw proto int would shift every value by one (MPI→OPENMP, etc.).
- The queue-default cluster (`defaultQueueName`/`defaultNodeCount`/`defaultCPUCount`/`defaultWalltime`) maps the proto-zero 'unset' sentinels back to `None` so the serializer renders `null` as Thrift did.
- `userHasWriteAccess` migrates to the gRPC sharing helper.

## Test plan
- `manage.py check` clean.
- Accessible deployments list returns 200 against the live backend.
- Offline serializer render with real **nested** protobuf confirms command/env lists adapt with all fields, `parallelism` maps to the correct Thrift int for every value (SERIAL/MPI/OPENMP/CRAY_MPI), queue-defaults render `null`, and `userHasWriteAccess` resolves via sharing.
- Note: the dev backend has no compute resources to seed a full deployment, so nested live data was validated via the offline render against real protobuf.