### PR TITLE
feat(portal): repoint experiment statistics to gRPC (Track D, D2)

### DIFF
--- a/airavata-django-portal/django_airavata/apps/api/grpc_adapters.py
+++ b/airavata-django-portal/django_airavata/apps/api/grpc_adapters.py
@@ -284,6 +284,28 @@ def experiment_summary(pb):
     )
 
 
+def experiment_statistics(pb):
+    """gRPC ``ExperimentStatistics`` -> ``ExperimentStatisticsSerializer`` shape.
+
+    A wrapper of per-state counts plus per-state experiment-summary lists, each
+    list adapted with :func:`experiment_summary`.
+    """
+    return SimpleNamespace(
+        allExperimentCount=pb.all_experiment_count,
+        completedExperimentCount=pb.completed_experiment_count,
+        cancelledExperimentCount=pb.cancelled_experiment_count,
+        failedExperimentCount=pb.failed_experiment_count,
+        createdExperimentCount=pb.created_experiment_count,
+        runningExperimentCount=pb.running_experiment_count,
+        allExperiments=[experiment_summary(s) for s in pb.all_experiments],
+        completedExperiments=[experiment_summary(s) for s in pb.completed_experiments],
+        failedExperiments=[experiment_summary(s) for s in pb.failed_experiments],
+        cancelledExperiments=[experiment_summary(s) for s in pb.cancelled_experiments],
+        createdExperiments=[experiment_summary(s) for s in pb.created_experiments],
+        runningExperiments=[experiment_summary(s) for s in pb.running_experiments],
+    )
+
+
 def credential_summary(pb):
     """gRPC ``CredentialSummary`` protobuf -> ``CredentialSummarySerializer`` shape."""
     return SimpleNamespace(

--- a/airavata-django-portal/django_airavata/apps/api/views.py
+++ b/airavata-django-portal/django_airavata/apps/api/views.py
@@ -1896,9 +1896,11 @@ class ExperimentStatisticsView(APIView):
         limit = int(request.GET.get('limit', '50'))
         offset = int(request.GET.get('offset', '0'))
 
-        statistics = request.airavata_client.getExperimentStatistics(
-            request.authz_token, settings.GATEWAY_ID, from_time, to_time,
-            username, application_name, resource_hostname, limit, offset)
+        statistics = grpc_adapters.experiment_statistics(
+            request.airavata.research.get_experiment_statistics(
+                settings.GATEWAY_ID, from_time, to_time,
+                username or "", application_name or "", resource_hostname or "",
+                limit, offset))
         serializer = self.serializer_class(statistics, context={'request': request})
 
         paginator = pagination.LimitOffsetPagination()


### PR DESCRIPTION
## Summary
Migrate `ExperimentStatisticsView` from the Thrift client to the gRPC research facade (`research.get_experiment_statistics`). The new `experiment_statistics` adapter maps the per-state counts and adapts each per-state experiment-summary list with the existing `experiment_summary` adapter. `None` query params (`userName`/`applicationName`/`resourceHostName`) become empty strings for the proto request.

## Test plan
- `manage.py check` clean.
- The endpoint returns 200 with the correct paginated structure live against the empty gateway.
- Offline serializer render confirms counts and summary lists render correctly.