### PR TITLE
feat(portal): repoint gateway profile + storage preference reads to gRPC (Track D, D2)

### DIFF
--- a/airavata-django-portal/django_airavata/apps/api/grpc_adapters.py
+++ b/airavata-django-portal/django_airavata/apps/api/grpc_adapters.py
@@ -538,6 +538,55 @@ def group_resource_profile(pb):
     )
 
 
+def storage_preference(pb):
+    """gRPC ``StoragePreference`` -> ``StoragePreferenceSerializer`` shape."""
+    return SimpleNamespace(
+        storageResourceId=pb.storage_resource_id,
+        loginUserName=pb.login_user_name,
+        fileSystemRootLocation=pb.file_system_root_location,
+        resourceSpecificCredentialStoreToken=pb.resource_specific_credential_store_token,
+    )
+
+
+def _compute_resource_preference(pb):
+    """gRPC ``ComputeResourcePreference`` -> auto-generated serializer shape."""
+    return SimpleNamespace(
+        computeResourceId=pb.compute_resource_id,
+        overridebyAiravata=pb.override_by_airavata,
+        loginUserName=pb.login_user_name,
+        # rendered as raw ints; bridge by name (name-divergent maps).
+        preferredJobSubmissionProtocol=_thrift_enum_mapped(
+            pb, 'preferred_job_submission_protocol', _JOB_SUBMISSION_PROTOCOL),
+        preferredDataMovementProtocol=_thrift_enum_mapped(
+            pb, 'preferred_data_movement_protocol', _DATA_MOVEMENT_PROTOCOL),
+        preferredBatchQueue=pb.preferred_batch_queue,
+        scratchLocation=pb.scratch_location,
+        allocationProjectNumber=pb.allocation_project_number,
+        resourceSpecificCredentialStoreToken=pb.resource_specific_credential_store_token,
+        usageReportingGatewayId=pb.usage_reporting_gateway_id,
+        qualityOfService=pb.quality_of_service,
+        reservation=pb.reservation,
+        reservationStartTime=pb.reservation_start_time or None,
+        reservationEndTime=pb.reservation_end_time or None,
+        sshAccountProvisioner=pb.ssh_account_provisioner,
+        sshAccountProvisionerConfig=dict(pb.ssh_account_provisioner_config),
+        sshAccountProvisionerAdditionalInfo=pb.ssh_account_provisioner_additional_info,
+    )
+
+
+def gateway_resource_profile(pb):
+    """gRPC ``GatewayResourceProfile`` -> ``GatewayResourceProfileSerializer`` shape."""
+    return SimpleNamespace(
+        gatewayID=pb.gateway_id,
+        credentialStoreToken=pb.credential_store_token,
+        computeResourcePreferences=[
+            _compute_resource_preference(p) for p in pb.compute_resource_preferences],
+        storagePreferences=[storage_preference(p) for p in pb.storage_preferences],
+        identityServerTenant=pb.identity_server_tenant,
+        identityServerPwdCredToken=pb.identity_server_pwd_cred_token,
+    )
+
+
 # --- Experiment tree -------------------------------------------------------
 #
 # getExperiment returns the full ExperimentModel including the processes tree

--- a/airavata-django-portal/django_airavata/apps/api/views.py
+++ b/airavata-django-portal/django_airavata/apps/api/views.py
@@ -1447,9 +1447,9 @@ class CredentialSummaryViewSet(APIBackedViewSet):
 class CurrentGatewayResourceProfile(APIView):
 
     def get(self, request, format=None):
-        gateway_resource_profile = \
-            request.airavata_client.getGatewayResourceProfile(
-                request.authz_token, settings.GATEWAY_ID)
+        gateway_resource_profile = grpc_adapters.gateway_resource_profile(
+            request.airavata.compute.get_gateway_resource_profile(
+                settings.GATEWAY_ID))
         serializer = serializers.GatewayResourceProfileSerializer(
             gateway_resource_profile, context={'request': request})
         return Response(serializer.data)
@@ -1471,8 +1471,8 @@ class CurrentGatewayResourceProfile(APIView):
 class ExperimentArchiveView(APIView):
 
     def get(self, request, experiment_id=None, format=None):
-        experiment: ExperimentModel = request.airavata_client.getExperiment(
-            request.authz_token, experiment_id)
+        experiment = grpc_adapters.experiment(
+            request.airavata.research.get_experiment(experiment_id))
         result = dict(archived=False, archive_name=None, created_date=None,
                       max_age=settings.GATEWAY_USER_DATA_ARCHIVE_MAX_AGE_DAYS)
         try:
@@ -1508,12 +1508,16 @@ class StoragePreferenceViewSet(APIBackedViewSet):
     lookup_field = 'storage_resource_id'
 
     def get_list(self):
-        return self.request.airavata_client.getAllGatewayStoragePreferences(
-            self.authz_token, settings.GATEWAY_ID)
+        return [
+            grpc_adapters.storage_preference(p)
+            for p in self.request.airavata.compute.get_all_gateway_storage_preferences(
+                settings.GATEWAY_ID)
+        ]
 
     def get_instance(self, lookup_value):
-        return self.request.airavata_client.getGatewayStoragePreference(
-            self.authz_token, settings.GATEWAY_ID, lookup_value)
+        return grpc_adapters.storage_preference(
+            self.request.airavata.compute.get_gateway_storage_preference(
+                settings.GATEWAY_ID, lookup_value))
 
     def perform_create(self, serializer):
         storage_preference = serializer.save()


### PR DESCRIPTION
## Summary
Migrate the gateway resource profile and gateway storage preference reads from the Thrift client to the gRPC **compute** facade, plus the experiment archive view to the research facade (reusing the `experiment` adapter).

- `CurrentGatewayResourceProfile.get` → `compute.get_gateway_resource_profile`
- `StoragePreferenceViewSet.get_list`/`get_instance` → `compute.get_all_gateway_storage_preferences` / `get_gateway_storage_preference`
- `ExperimentArchiveView.get` → `research.get_experiment`

New `gateway_resource_profile` adapter recursively adapts the `computeResourcePreferences` (`ComputeResourcePreference` — whose preferred job-submission / data-movement protocol enums render as raw ints and reuse the existing name-divergent maps, plus an `sshAccountProvisionerConfig` map) and the `storagePreferences`, backed by a new public `storage_preference` adapter the `StoragePreferenceViewSet` also uses. `userHasWriteAccess` on the gateway profile is gateway-admin-based (unchanged). Write actions stay on Thrift pending D3.

## Test plan
- `manage.py check` clean.
- The gateway resource profile and the **real dev storage preference** both round-trip live with correct data (the storage pref returns the real `storageResourceId`, `loginUserName`, root location, and credential token).
- Offline render exercises a populated compute resource preference (protocol enums bridged to the right Thrift ints) and the empty-token → `null` conversion.