### PR TITLE
feat(portal): repoint credential writes to gRPC (Track D, D3)

### DIFF
--- a/airavata-django-portal/django_airavata/apps/api/grpc_requests.py
+++ b/airavata-django-portal/django_airavata/apps/api/grpc_requests.py
@@ -59,6 +59,18 @@ def project(t):
     )
 
 
+def password_credential(gateway_id, portal_user_name, login_user_name,
+                         password, description):
+    """Build a proto ``PasswordCredential`` from the create-password request."""
+    return _pb2("credential.store.credential_store_pb2").PasswordCredential(
+        gateway_id=gateway_id or '',
+        portal_user_name=portal_user_name or '',
+        login_user_name=login_user_name or '',
+        password=password or '',
+        description=description or '',
+    )
+
+
 def application_module(t):
     """Thrift ``ApplicationModule`` -> proto ``ApplicationModule``."""
     return _pb2("appcatalog.appdeployment.app_deployment_pb2").ApplicationModule(

--- a/airavata-django-portal/django_airavata/apps/api/views.py
+++ b/airavata-django-portal/django_airavata/apps/api/views.py
@@ -1412,10 +1412,11 @@ class CredentialSummaryViewSet(APIBackedViewSet):
         if 'description' not in request.data:
             raise ParseError("'description' is required in request")
         description = request.data.get('description')
-        token_id = self.request.airavata_client.generateAndRegisterSSHKeys(
-            request.authz_token, description)
-        credential_summary = self.request.airavata_client.getCredentialSummary(
-            request.authz_token, token_id)
+        token_id = request.airavata.credential.generate_and_register_ssh_keys(
+            self.gateway_id, self.username, description)
+        credential_summary = grpc_adapters.credential_summary(
+            request.airavata.credential.get_credential_summary(
+                token_id, self.gateway_id))
         serializer = self.get_serializer(credential_summary)
         return Response(serializer.data)
 
@@ -1429,20 +1430,23 @@ class CredentialSummaryViewSet(APIBackedViewSet):
         username = request.data.get('username')
         password = request.data.get('password')
         description = request.data.get('description')
-        token_id = self.request.airavata_client.registerPwdCredential(
-            request.authz_token, username, password, description)
-        credential_summary = self.request.airavata_client.getCredentialSummary(
-            request.authz_token, token_id)
+        token_id = request.airavata.credential.register_pwd_credential(
+            self.gateway_id,
+            grpc_requests.password_credential(
+                self.gateway_id, self.username, username, password, description))
+        credential_summary = grpc_adapters.credential_summary(
+            request.airavata.credential.get_credential_summary(
+                token_id, self.gateway_id))
         serializer = self.get_serializer(credential_summary)
         return Response(serializer.data)
 
     def perform_destroy(self, instance):
         if instance.type == SummaryType.SSH:
-            self.request.airavata_client.deleteSSHPubKey(
-                self.authz_token, instance.token)
+            self.request.airavata.credential.delete_ssh_pub_key(
+                instance.token, self.gateway_id)
         elif instance.type == SummaryType.PASSWD:
-            self.request.airavata_client.deletePWDCredential(
-                self.authz_token, instance.token)
+            self.request.airavata.credential.delete_pwd_credential(
+                instance.token, self.gateway_id)
 
 
 class CurrentGatewayResourceProfile(APIView):


### PR DESCRIPTION
## Summary
Migrate `CredentialSummaryViewSet.create_ssh` / `create_password` / `perform_destroy` from the Thrift client to the gRPC credential facade (`generate_and_register_ssh_keys` / `register_pwd_credential` / `delete_ssh_pub_key` / `delete_pwd_credential`), plus the create-time read-back via `get_credential_summary` + the existing `credential_summary` read adapter. `create_password` builds a proto `PasswordCredential` via the new `grpc_requests.password_credential` helper (the Thrift call passed username/password/description positionally; the facade takes the message).

## Test plan
- `manage.py check` clean.
- Note: the dev backend NPEs on SSH credential registration for the service account (the same backend limitation noted for the credential reads), so the live create was not exercised end-to-end; the calls mirror the validated read family.