### PR TITLE
fix(portal): de-Thrift the notifications context processor (Track D)

### DIFF
--- a/airavata-django-portal/django_airavata/context_processors.py
+++ b/airavata-django-portal/django_airavata/context_processors.py
@@ -10,17 +10,21 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.urls import reverse
 
 from django_airavata.app_config import AiravataAppConfig
+from django_airavata.apps.api import grpc_adapters
 from django_airavata.apps.api.models import User_Notifications
 
 logger = logging.getLogger(__name__)
 
 
 def get_notifications(request):
-    if request.user.is_authenticated and hasattr(request, 'airavata_client'):
+    if request.user.is_authenticated and getattr(request, 'authz_token', None):
         unread_notifications = 0
         try:
-            notifications = request.airavata_client.getAllNotifications(
-                request.authz_token, settings.GATEWAY_ID)
+            notifications = [
+                grpc_adapters.notification(n)
+                for n in request.airavata.research.get_all_notifications(
+                    settings.GATEWAY_ID)
+            ]
         except Exception:
             logger.warning("Failed to load notifications")
             notifications = []


### PR DESCRIPTION
## Summary

The `get_notifications` template **context processor** ran a Thrift `getAllNotifications` on every authenticated HTML page render. With the legacy Thrift server gone, that call blocked for the full socket read-timeout (~25s), so **every server-rendered page hung** (dashboard, projects, experiments, …) — even though the page's own view and the JSON API endpoints were already on gRPC.

This was the concrete blocker preventing the real UI from loading.

## Change

- Repoint `get_notifications` to the gRPC `research` facade (`get_all_notifications`) and adapt each protobuf `Notification` with the existing `grpc_adapters.notification` — the same adapter the migrated `ManageNotificationViewSet` (#173) uses — so the JSON payload handed to the frontend is byte-for-byte unchanged (`notificationId`, `title`, `notificationMessage`, `publishedTime`, `expirationTime`, `priority`, `url`, `is_read`).
- The guard switches from `hasattr(request, 'airavata_client')` to `getattr(request, 'authz_token', None)` (the gRPC client needs the token); failures still fall back to an empty list.

## Testing

- `manage.py check` — green.
- Live, against the running backend, logged in as a real user:
  - `/workspace/dashboard`: **25s hang → 200 in ~0.02s**
  - `/workspace/projects`: 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)