### PR TITLE
feat(portal): de-Thrift group management to the gRPC sharing facade (Track D, D5)

### DIFF
--- a/airavata-django-portal/django_airavata/apps/api/grpc_adapters.py
+++ b/airavata-django-portal/django_airavata/apps/api/grpc_adapters.py
@@ -832,6 +832,18 @@ def experiment(pb):
     )
 
 
+def group(pb):
+    """gRPC ``GroupModel`` -> ``GroupSerializer`` shape."""
+    return SimpleNamespace(
+        id=pb.id,
+        name=pb.name,
+        ownerId=pb.owner_id,
+        description=pb.description or None,
+        members=list(pb.members),
+        admins=list(pb.admins),
+    )
+
+
 def notification(pb):
     """gRPC ``Notification`` -> ``NotificationSerializer`` shape."""
     return SimpleNamespace(

--- a/airavata-django-portal/django_airavata/apps/api/grpc_requests.py
+++ b/airavata-django-portal/django_airavata/apps/api/grpc_requests.py
@@ -543,3 +543,15 @@ def group_resource_profile(t):
         updated_time=t.updatedTime or 0,
         default_credential_store_token=t.defaultCredentialStoreToken or '',
     )
+
+
+def group(t):
+    """Thrift ``GroupModel`` -> proto ``GroupModel`` request message."""
+    return _pb2("group.group_manager_pb2").GroupModel(
+        id=t.id or '',
+        name=t.name or '',
+        owner_id=t.ownerId or '',
+        description=t.description or '',
+        members=list(t.members or []),
+        admins=list(t.admins or []),
+    )

--- a/airavata-django-portal/django_airavata/apps/api/serializers.py
+++ b/airavata-django-portal/django_airavata/apps/api/serializers.py
@@ -232,8 +232,7 @@ class GroupSerializer(thrift_utils.create_serializer_class(GroupModel)):
 
     def get_isAdmin(self, group):
         request = self.context['request']
-        return request.profile_service['group_manager'].hasAdminAccess(
-            request.authz_token,
+        return request.airavata.sharing.gm_has_admin_access(
             group.id,
             request.user.username + "@" + settings.GATEWAY_ID)
 
@@ -263,9 +262,12 @@ class GroupSerializer(thrift_utils.create_serializer_class(GroupModel)):
         if 'GATEWAY_GROUPS' in request.session:
             return request.session['GATEWAY_GROUPS']
         else:
-            gateway_groups = request.airavata_client.getGatewayGroups(
-                request.authz_token)
-            return copy.deepcopy(gateway_groups.__dict__)
+            gg = request.airavata.compute.get_gateway_groups()
+            return {
+                'adminsGroupId': gg.admins_group_id,
+                'readOnlyAdminsGroupId': gg.read_only_admins_group_id,
+                'defaultGatewayUsersGroupId': gg.default_gateway_users_group_id,
+            }
 
 
 class ProjectSerializer(

--- a/airavata-django-portal/django_airavata/apps/api/views.py
+++ b/airavata-django-portal/django_airavata/apps/api/views.py
@@ -93,53 +93,49 @@ class GroupViewSet(APIBackedViewSet):
 
         class GroupResultsIterator(APIResultIterator):
             def get_results(self, limit=-1, offset=0):
-                group_manager = view.request.profile_service['group_manager']
-                groups = group_manager.getGroups(view.authz_token)
+                groups = [
+                    grpc_adapters.group(g)
+                    for g in view.request.airavata.sharing.gm_get_groups()
+                ]
                 end = offset + limit if limit > 0 else len(groups)
                 return groups[offset:end] if groups else []
 
         return GroupResultsIterator()
 
     def get_instance(self, lookup_value):
-        return self.request.profile_service['group_manager'].getGroup(
-            self.authz_token, lookup_value)
+        return grpc_adapters.group(
+            self.request.airavata.sharing.gm_get_group(lookup_value))
 
     def perform_create(self, serializer):
         group = serializer.save()
-        group_id = self.request.profile_service['group_manager'].createGroup(
-            self.authz_token, group)
+        group_id = self.request.airavata.sharing.gm_create_group(
+            grpc_requests.group(group))
         group.id = group_id
         users_added_to_group = set(group.members) - {group.ownerId}
         self._send_users_added_to_group(users_added_to_group, group)
 
     def perform_update(self, serializer):
         group = serializer.save()
-        group_manager_client = self.request.profile_service['group_manager']
+        sharing = self.request.airavata.sharing
         if len(group._added_members) > 0:
-            group_manager_client.addUsersToGroup(
-                self.authz_token, group._added_members, group.id)
+            sharing.gm_add_users_to_group(group._added_members, group.id)
             self._send_users_added_to_group(group._added_members, group)
         if len(group._removed_members) > 0:
-            group_manager_client.removeUsersFromGroup(
-                self.authz_token, group._removed_members, group.id)
+            sharing.gm_remove_users_from_group(group._removed_members, group.id)
         if len(group._added_admins) > 0:
-            group_manager_client.addGroupAdmins(
-                self.authz_token, group.id, group._added_admins)
+            sharing.gm_add_group_admins(group.id, group._added_admins)
         if len(group._removed_admins) > 0:
-            group_manager_client.removeGroupAdmins(
-                self.authz_token, group.id, group._removed_admins)
-        group_manager_client.updateGroup(self.authz_token, group)
+            sharing.gm_remove_group_admins(group.id, group._removed_admins)
+        sharing.gm_update_group(grpc_requests.group(group))
 
     def perform_destroy(self, group):
-        group_manager_client = self.request.profile_service['group_manager']
-        group_manager_client.deleteGroup(
-            self.authz_token, group.id, group.ownerId)
+        self.request.airavata.sharing.gm_delete_group(group.id, group.ownerId)
 
     def _send_users_added_to_group(self, internal_user_ids, group):
         for internal_user_id in internal_user_ids:
             user_id, gateway_id = internal_user_id.rsplit("@", maxsplit=1)
-            user_profile = self.request.profile_service['user_profile'].getUserProfileById(
-                self.authz_token, user_id, gateway_id)
+            user_profile = self.request.airavata.iam.get_user_profile_by_id(
+                user_id, gateway_id)
             signals.user_added_to_group.send(
                 sender=self.__class__,
                 user=user_profile,

--- a/airavata-django-portal/django_airavata/apps/auth/middleware.py
+++ b/airavata-django-portal/django_airavata/apps/auth/middleware.py
@@ -34,7 +34,8 @@ def _gateway_groups_dict(request):
     """Fetch the gateway's admin group ids via the gRPC compute facade."""
     gg = request.airavata.compute.get_gateway_groups()
     return {'adminsGroupId': gg.admins_group_id,
-            'readOnlyAdminsGroupId': gg.read_only_admins_group_id}
+            'readOnlyAdminsGroupId': gg.read_only_admins_group_id,
+            'defaultGatewayUsersGroupId': gg.default_gateway_users_group_id}
 
 
 def set_admin_group_attributes(request, gateway_groups=None):

--- a/airavata-django-portal/django_airavata/apps/auth/signals.py
+++ b/airavata-django-portal/django_airavata/apps/auth/signals.py
@@ -17,9 +17,9 @@ log = logging.getLogger(__name__)
 def email_user_added_to_group(sender, user, groups, request, **kwargs):
     context = Context({
         "email": user.emails[0],
-        "first_name": user.firstName,
-        "last_name": user.lastName,
-        "username": user.userId,
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "username": user.user_id,
         "portal_title": settings.PORTAL_TITLE,
         "dashboard_url": request.build_absolute_uri(
             reverse("django_airavata_workspace:dashboard")),


### PR DESCRIPTION
## Summary

`GroupViewSet` and `GroupSerializer` ran on the Thrift `group_manager` profile-service client, so `/api/groups/` (and every page that loads sharing/group data) blocked on the dead Thrift server's socket read-timeout (**~25s hang**). This repoints group management to the gRPC `sharing` facade's GroupManager (`gm_*`) operations.

## Changes

- **`GroupViewSet`** → `request.airavata.sharing.gm_*`: `gm_get_groups` / `gm_get_group` / `gm_create_group` / `gm_add_users_to_group` / `gm_remove_users_from_group` / `gm_add_group_admins` / `gm_remove_group_admins` / `gm_update_group` / `gm_delete_group`. `_send_users_added_to_group` loads the added user's profile via `request.airavata.iam.get_user_profile_by_id`.
- **`GroupSerializer`**: `get_isAdmin` → `sharing.gm_has_admin_access`; `_gateway_groups` → `compute.get_gateway_groups` (now also surfaces `defaultGatewayUsersGroupId`, which the serializer reads).
- **`grpc_adapters.group`** (proto `GroupModel` → serializer shape) and **`grpc_requests.group`** (reverse) added.
- **`_gateway_groups_dict`** middleware helper extended with the third group id, for consistency with the session-cached dict the serializer reads.
- The `user_added_to_group` signal now carries a protobuf `UserProfile`, so `email_user_added_to_group` reads `first_name`/`last_name`/`user_id`.

## Testing

- `manage.py check` — green.
- `grpc_adapters.group` round-trips (proto → adapter → reverse-proto) field-for-field.
- Live: `/api/groups/` **25s hang → 200 in ~0.02s** (empty list).
- Note: creating a group / initializing `GatewayGroups` isn't seedable in the ephemeral dev backend ("Error while committing the transaction"), so the serializer's group-flag fields are migrated 1:1 from their Thrift equivalents rather than re-validated against live multi-group data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)