### PR TITLE
refactor(portal): de-Thrift residual experiment/app-catalog read calls to gRPC (Track D)

### DIFF
--- a/airavata-django-portal/django_airavata/apps/api/output_views.py
+++ b/airavata-django-portal/django_airavata/apps/api/output_views.py
@@ -175,8 +175,8 @@ def generate_data(request,
                   **kwargs):
     output_view_provider = _get_output_view_provider(output_view_provider_id)
     # TODO if output_view_provider is None, return 404
-    experiment = request.airavata_client.getExperiment(
-        request.authz_token, experiment_id)
+    experiment = grpc_adapters.experiment(
+        request.airavata.research.get_experiment(experiment_id))
     experiment_output = [o
                          for o in experiment.experimentOutputs
                          if o.name == experiment_output_name]

--- a/airavata-django-portal/django_airavata/apps/api/views.py
+++ b/airavata-django-portal/django_airavata/apps/api/views.py
@@ -271,9 +271,11 @@ class ExperimentViewSet(mixins.CreateModelMixin,
 
     @action(methods=['post'], detail=True)
     def clone(self, request, experiment_id=None):
+        # experiment_util.clone is the launch/clone orchestration (still Thrift);
+        # re-fetch the cloned experiment via gRPC.
         cloned_experiment_id = experiment_util.clone(request, experiment_id)
-        cloned_experiment = request.airavata_client.getExperiment(
-            self.authz_token, cloned_experiment_id)
+        cloned_experiment = grpc_adapters.experiment(
+            request.airavata.research.get_experiment(cloned_experiment_id))
         serializer = self.serializer_class(
             cloned_experiment, context={'request': request})
         return Response(serializer.data)
@@ -347,8 +349,8 @@ class FullExperimentViewSet(mixins.RetrieveModelMixin,
     def get_instance(self, lookup_value):
         """Get FullExperiment instance with resolved references."""
         # TODO: move loading experiment and references to airavata_sdk?
-        experimentModel = self.request.airavata_client.getExperiment(
-            self.authz_token, lookup_value)
+        experimentModel = grpc_adapters.experiment(
+            self.request.airavata.research.get_experiment(lookup_value))
         outputDataProducts = [
             grpc_adapters.data_product(
                 self.request.airavata.research.get_data_product(output.value))
@@ -368,8 +370,9 @@ class FullExperimentViewSet(mixins.RetrieveModelMixin,
             if output.value.startswith('airavata-dp')]
         appInterfaceId = experimentModel.executionId
         try:
-            applicationInterface = self.request.airavata_client \
-                .getApplicationInterface(self.authz_token, appInterfaceId)
+            applicationInterface = grpc_adapters.application_interface(
+                self.request.airavata.research.get_application_interface(
+                    appInterfaceId))
         except Exception as e:
             log.warning(f"Failed to load app interface: {e}")
             applicationInterface = None
@@ -396,8 +399,9 @@ class FullExperimentViewSet(mixins.RetrieveModelMixin,
         try:
             if applicationInterface is not None:
                 appModuleId = applicationInterface.applicationModules[0]
-                applicationModule = self.request.airavata_client \
-                    .getApplicationModule(self.authz_token, appModuleId)
+                applicationModule = grpc_adapters.application_module(
+                    self.request.airavata.research.get_application_module(
+                        appModuleId))
             else:
                 log.warning(
                     "Cannot load application model since app interface failed to load")
@@ -410,24 +414,25 @@ class FullExperimentViewSet(mixins.RetrieveModelMixin,
             comp_res_sched = user_conf.computationalResourceScheduling
             compute_resource_id = comp_res_sched.resourceHostId
         try:
-            compute_resource = self.request.airavata_client.getComputeResource(
-                self.authz_token, compute_resource_id) \
+            compute_resource = grpc_adapters.compute_resource(
+                self.request.airavata.compute.get_compute_resource(
+                    compute_resource_id)) \
                 if compute_resource_id else None
         except Exception:
             log.exception("Failed to load compute resource for {}".format(
                 compute_resource_id), extra={'request': self.request})
             compute_resource = None
-        if self.request.airavata_client.userHasAccess(
-                self.authz_token,
-                experimentModel.projectId,
-                ResourcePermissionType.READ):
-            project = self.request.airavata_client.getProject(
-                self.authz_token, experimentModel.projectId)
+        if serializers.user_has_access(
+                self.request, experimentModel.projectId, 'READ'):
+            project = grpc_adapters.project(
+                self.request.airavata.research.get_project(
+                    experimentModel.projectId))
         else:
             # User may not have access to project, only experiment
             project = None
-        job_details = self.request.airavata_client.getJobDetails(
-            self.authz_token, lookup_value)
+        job_details = [
+            grpc_adapters.job_model(j)
+            for j in self.request.airavata.research.get_job_details(lookup_value)]
         full_experiment = serializers.FullExperiment(
             experimentModel,
             project=project,
@@ -472,8 +477,10 @@ class ApplicationModuleViewSet(APIBackedViewSet):
 
     @action(detail=True)
     def application_interface(self, request, app_module_id):
-        all_app_interfaces = request.airavata_client.getAllApplicationInterfaces(
-            self.authz_token, self.gateway_id)
+        all_app_interfaces = [
+            grpc_adapters.application_interface(i)
+            for i in request.airavata.research.get_all_application_interfaces(
+                self.gateway_id)]
         app_interfaces = []
         for app_interface in all_app_interfaces:
             if not app_interface.applicationModules:
@@ -498,8 +505,10 @@ class ApplicationModuleViewSet(APIBackedViewSet):
 
     @action(detail=True)
     def application_deployments(self, request, app_module_id):
-        all_deployments = self.request.airavata_client.getAllApplicationDeployments(
-            self.authz_token, self.gateway_id)
+        all_deployments = [
+            grpc_adapters.application_deployment(d)
+            for d in self.request.airavata.research
+            .get_accessible_application_deployments(self.gateway_id)]
         app_deployments = [
             dep for dep in all_deployments if dep.appModuleId == app_module_id]
         serializer = serializers.ApplicationDeploymentDescriptionSerializer(

--- a/airavata-django-portal/django_airavata/apps/workspace/views.py
+++ b/airavata-django-portal/django_airavata/apps/workspace/views.py
@@ -132,8 +132,10 @@ def create_experiment(request, app_module_id):
 def edit_experiment(request, experiment_id):
     request.active_nav_item = 'experiments'
 
-    experiment = request.airavata_client.getExperiment(request.authz_token, experiment_id)
-    applicationInterface = request.airavata_client.getApplicationInterface(request.authz_token, experiment.executionId)
+    experiment = grpc_adapters.experiment(
+        request.airavata.research.get_experiment(experiment_id))
+    applicationInterface = grpc_adapters.application_interface(
+        request.airavata.research.get_application_interface(experiment.executionId))
     app_module_id = applicationInterface.applicationModules[0]
     context = {
         'bundle_name': 'edit-experiment',


### PR DESCRIPTION
## Summary

Migrate the remaining straggler Thrift **reads** (those not entangled with the storage / data-product write path, which is D4.2/D4.3) to the gRPC facades, reusing the adapters established in the D2 read families.

- **`FullExperimentViewSet.get_instance`**: `getExperiment` / `getApplicationInterface` / `getApplicationModule` / `getComputeResource` / `getProject` / `getJobDetails` / `userHasAccess` → research/compute facades + adapters and the `user_has_access` sharing helper. (Its data-product reads were already gRPC from D4.1 / #186.)
- **`ApplicationModuleViewSet.application_interface` / `application_deployments`** actions: `getAllApplicationInterfaces` / `getAllApplicationDeployments` → `research.get_all_application_interfaces` / `get_accessible_application_deployments` + adapters, keeping the same module-id filtering.
- **`ExperimentViewSet.clone`**: re-fetch the cloned experiment via `research.get_experiment` (the `experiment_util.clone` orchestration stays Thrift — separate concern).
- **`output_views.generate_data`**: `getExperiment` → `research.get_experiment`.
- **`workspace/views.edit_experiment`**: `getExperiment` / `getApplicationInterface` → research facades (derives `app_module_id` for template rendering).

After this, the only remaining `request.airavata_client` call sites are the two intentionally-deferred admin views — `GlobusJobSubmissionView` (broken `getClo`, no facade getter) and `UnicoreDataMovementView` (no facade getter) — both already flagged with a TODO.

## Validation

REST/JSON contract unchanged (reuses the proven D2 adapters). `manage.py check` clean; all view modules import; the facade calls round-trip structurally against the live backend (empty lists / proper errors for absent data, matching the dev-data limits).