### PR TITLE
refactor(portal): make per-protocol interface detail serializers proto-native (Track D)

### DIFF
--- a/airavata-django-portal/django_airavata/apps/api/grpc_adapters.py
+++ b/airavata-django-portal/django_airavata/apps/api/grpc_adapters.py
@@ -14,11 +14,7 @@ serializers are made protobuf-native.
 from types import SimpleNamespace
 
 from airavata.model.appcatalog.computeresource.ttypes import (
-    JobManagerCommand as _ThriftJobManagerCommand,
     JobSubmissionProtocol as _ThriftJobSubmissionProtocol,
-    MonitorMode as _ThriftMonitorMode,
-    ProviderName as _ThriftProviderName,
-    ResourceJobManagerType as _ThriftResourceJobManagerType,
 )
 from airavata.model.appcatalog.groupresourceprofile.ttypes import (
     ResourceType as _ThriftResourceType,
@@ -34,7 +30,6 @@ from airavata.model.data.replica.ttypes import (
 )
 from airavata.model.data.movement.ttypes import (
     DataMovementProtocol as _ThriftDataMovementProtocol,
-    SecurityProtocol as _ThriftSecurityProtocol,
 )
 from airavata.model.experiment.ttypes import (
     ExperimentType as _ThriftExperimentType,
@@ -682,153 +677,6 @@ def user_profile(pb):
         timeZone=pb.time_zone or None,
         nsfDemographics=None,
         customDashboard=None,
-    )
-
-
-# --- Per-protocol job-submission / data-movement interface details ----------
-# These admin-only detail views render a single protocol's submission/movement
-# model via the auto-generated serializer, so the adapter exposes Thrift attribute
-# names. SecurityProtocol/ResourceJobManagerType/ProviderName are prefix-aligned
-# (proto *_UNKNOWN sentinel -> None). MonitorMode NAMES diverge (proto MONITOR_FORK
-# / MONITOR_LOCAL vs Thrift FORK / LOCAL) so it needs an explicit map. The
-# ResourceJobManager carries two enum-keyed map<int32,string> fields whose int keys
-# hold proto enum values, bridged to the Thrift enum int by name (like _file_systems).
-
-# proto MonitorMode member name -> Thrift MonitorMode value (names diverge for the
-# FORK/LOCAL members, which proto prefixes with MONITOR_).
-_MONITOR_MODE = {
-    'POLL_JOB_MANAGER': _ThriftMonitorMode.POLL_JOB_MANAGER,
-    'CLOUD_JOB_MONITOR': _ThriftMonitorMode.CLOUD_JOB_MONITOR,
-    'JOB_EMAIL_NOTIFICATION_MONITOR': _ThriftMonitorMode.JOB_EMAIL_NOTIFICATION_MONITOR,
-    'XSEDE_AMQP_SUBSCRIBE': _ThriftMonitorMode.XSEDE_AMQP_SUBSCRIBE,
-    'MONITOR_FORK': _ThriftMonitorMode.FORK,
-    'MONITOR_LOCAL': _ThriftMonitorMode.LOCAL,
-}
-
-
-def _enum_keyed_map(pb_map, proto_enum, thrift_enum):
-    """proto map<int32, string> whose int key holds a ``proto_enum`` value ->
-    {Thrift enum member: value}, bridging the key by NAME (proto and Thrift assign
-    different ints to the same member). The Thrift model declared these as
-    enum-keyed maps, so the serializer's ``DictField`` rendered ``str(member)``
-    (e.g. ``'JobManagerCommand.SUBMISSION'``) -> keep the Thrift IntEnum member as
-    the key to reproduce that exact representation. Unknown keys (e.g. the zero
-    sentinel) are dropped.
-    """
-    result = {}
-    for k, v in pb_map.items():
-        name = proto_enum.DESCRIPTOR.values_by_number.get(k)
-        if name is None:
-            continue
-        thrift_member = getattr(thrift_enum, name.name, None)
-        if thrift_member is not None:
-            result[thrift_member] = v
-    return result
-
-
-def _resource_job_manager(pb):
-    """gRPC ``ResourceJobManager`` -> auto-generated serializer shape."""
-    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.computeresource import (  # noqa: E501
-        compute_resource_pb2,
-    )
-    from airavata_sdk.generated.org.apache.airavata.model.parallelism import (
-        parallelism_pb2,
-    )
-    return SimpleNamespace(
-        resourceJobManagerId=pb.resource_job_manager_id or None,
-        resourceJobManagerType=_thrift_enum_prefixed(
-            pb, 'resource_job_manager_type', _ThriftResourceJobManagerType,
-            'RESOURCE_JOB_MANAGER_TYPE_'),
-        pushMonitoringEndpoint=pb.push_monitoring_endpoint or None,
-        jobManagerBinPath=pb.job_manager_bin_path or None,
-        jobManagerCommands=_enum_keyed_map(
-            pb.job_manager_commands, compute_resource_pb2.JobManagerCommand,
-            _ThriftJobManagerCommand),
-        parallelismPrefix=_enum_keyed_map(
-            pb.parallelism_prefix, parallelism_pb2.ApplicationParallelismType,
-            _ThriftParallelismType),
-    )
-
-
-def local_job_submission(pb):
-    """gRPC ``LOCALSubmission`` -> auto-generated serializer shape."""
-    return SimpleNamespace(
-        jobSubmissionInterfaceId=pb.job_submission_interface_id,
-        resourceJobManager=_resource_job_manager(pb.resource_job_manager),
-        securityProtocol=_thrift_enum_prefixed(
-            pb, 'security_protocol', _ThriftSecurityProtocol,
-            'SECURITY_PROTOCOL_'),
-    )
-
-
-def ssh_job_submission(pb):
-    """gRPC ``SSHJobSubmission`` -> auto-generated serializer shape."""
-    return SimpleNamespace(
-        jobSubmissionInterfaceId=pb.job_submission_interface_id,
-        securityProtocol=_thrift_enum_prefixed(
-            pb, 'security_protocol', _ThriftSecurityProtocol,
-            'SECURITY_PROTOCOL_'),
-        resourceJobManager=_resource_job_manager(pb.resource_job_manager),
-        alternativeSSHHostName=pb.alternative_ssh_host_name or None,
-        sshPort=pb.ssh_port or None,
-        monitorMode=_thrift_enum_mapped(pb, 'monitor_mode', _MONITOR_MODE),
-        batchQueueEmailSenders=list(pb.batch_queue_email_senders),
-    )
-
-
-def cloud_job_submission(pb):
-    """gRPC ``CloudJobSubmission`` -> auto-generated serializer shape."""
-    return SimpleNamespace(
-        jobSubmissionInterfaceId=pb.job_submission_interface_id,
-        securityProtocol=_thrift_enum_prefixed(
-            pb, 'security_protocol', _ThriftSecurityProtocol,
-            'SECURITY_PROTOCOL_'),
-        nodeId=pb.node_id or None,
-        executableType=pb.executable_type or None,
-        providerName=_thrift_enum_prefixed(
-            pb, 'provider_name', _ThriftProviderName, 'PROVIDER_NAME_'),
-        userAccountName=pb.user_account_name or None,
-    )
-
-
-def unicore_job_submission(pb):
-    """gRPC ``UnicoreJobSubmission`` -> auto-generated serializer shape."""
-    return SimpleNamespace(
-        jobSubmissionInterfaceId=pb.job_submission_interface_id,
-        securityProtocol=_thrift_enum_prefixed(
-            pb, 'security_protocol', _ThriftSecurityProtocol,
-            'SECURITY_PROTOCOL_'),
-        unicoreEndPointURL=pb.unicore_end_point_url or None,
-    )
-
-
-def local_data_movement(pb):
-    """gRPC ``LOCALDataMovement`` -> auto-generated serializer shape."""
-    return SimpleNamespace(
-        dataMovementInterfaceId=pb.data_movement_interface_id,
-    )
-
-
-def scp_data_movement(pb):
-    """gRPC ``SCPDataMovement`` -> auto-generated serializer shape."""
-    return SimpleNamespace(
-        dataMovementInterfaceId=pb.data_movement_interface_id,
-        securityProtocol=_thrift_enum_prefixed(
-            pb, 'security_protocol', _ThriftSecurityProtocol,
-            'SECURITY_PROTOCOL_'),
-        alternativeSCPHostName=pb.alternative_scp_host_name or None,
-        sshPort=pb.ssh_port or None,
-    )
-
-
-def grid_ftp_data_movement(pb):
-    """gRPC ``GridFTPDataMovement`` -> auto-generated serializer shape."""
-    return SimpleNamespace(
-        dataMovementInterfaceId=pb.data_movement_interface_id,
-        securityProtocol=_thrift_enum_prefixed(
-            pb, 'security_protocol', _ThriftSecurityProtocol,
-            'SECURITY_PROTOCOL_'),
-        gridFTPEndPoints=list(pb.grid_ftp_end_points),
     )
 
 

--- a/airavata-django-portal/django_airavata/apps/api/serializers.py
+++ b/airavata-django-portal/django_airavata/apps/api/serializers.py
@@ -345,6 +345,40 @@ class ProtoFileSystemsMapField(serializers.Field):
             str(key_map[k]): v for k, v in value.items() if k in key_map}
 
 
+class ProtoEnumKeyedMapField(serializers.Field):
+    """Renders a proto ``map<int32, string>`` whose int key holds a proto enum
+    value as the ``{str(Thrift enum member): value}`` dict the old enum-keyed
+    Thrift map produced (e.g. ``{'JobManagerCommand.SUBMISSION': 'sbatch'}``).
+
+    Build via :func:`proto_enum_keyed_map_field`, which snapshots the proto-int ->
+    Thrift-member-str mapping. (Unlike ``ProtoFileSystemsMapField``, which mirrors
+    an i32-keyed Thrift map and emits the digit, this mirrors an enum-keyed Thrift
+    map and emits ``str(member)``.)
+    """
+
+    def __init__(self, key_labels, **kwargs):
+        self._key_labels = key_labels
+        kwargs.setdefault('read_only', True)
+        super().__init__(**kwargs)
+
+    def to_representation(self, value):
+        return {
+            self._key_labels[k]: v
+            for k, v in value.items() if k in self._key_labels}
+
+
+def proto_enum_keyed_map_field(proto_enum_descriptor, thrift_enum, **kwargs):
+    """Build a :class:`ProtoEnumKeyedMapField` mapping each proto enum int key to
+    ``str(Thrift enum member)`` by member name (proto and Thrift assign different
+    ints; unknown/zero-sentinel keys are dropped)."""
+    key_labels = {}
+    for v in proto_enum_descriptor.values:
+        thrift_member = getattr(thrift_enum, v.name, None)
+        if thrift_member is not None:
+            key_labels[v.number] = str(thrift_member)
+    return ProtoEnumKeyedMapField(key_labels=key_labels, **kwargs)
+
+
 class StoredJSONField(serializers.JSONField):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -884,6 +918,203 @@ class ComputeResourceDescriptionSerializer(serializers.Serializer):
         source='default_cpu_count', allow_null=True, required=False)
     defaultWalltime = serializers.IntegerField(
         source='default_walltime', allow_null=True, required=False)
+
+
+# --- Per-protocol job-submission / data-movement interface details ----------
+# Admin-only detail views rendering a single protocol's submission/movement model.
+# SecurityProtocol/ResourceJobManagerType/ProviderName are prefix-aligned; MonitorMode
+# names diverge (proto MONITOR_FORK/MONITOR_LOCAL -> Thrift FORK/LOCAL).
+_MONITOR_MODE_NAME_MAP = {'MONITOR_FORK': 'FORK', 'MONITOR_LOCAL': 'LOCAL'}
+
+
+def _security_protocol_field(**kwargs):
+    from airavata.model.data.movement.ttypes import (
+        SecurityProtocol as _ThriftSecurityProtocol,
+    )
+    from airavata_sdk.generated.org.apache.airavata.model.data.movement import (
+        data_movement_pb2,
+    )
+    return proto_enum_int_field(
+        data_movement_pb2.SecurityProtocol.DESCRIPTOR, _ThriftSecurityProtocol,
+        proto_prefix='SECURITY_PROTOCOL_', **kwargs)
+
+
+def _resource_job_manager_type_field(**kwargs):
+    from airavata.model.appcatalog.computeresource.ttypes import (
+        ResourceJobManagerType as _ThriftResourceJobManagerType,
+    )
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.computeresource import (  # noqa: E501
+        compute_resource_pb2,
+    )
+    return proto_enum_int_field(
+        compute_resource_pb2.ResourceJobManagerType.DESCRIPTOR,
+        _ThriftResourceJobManagerType,
+        proto_prefix='RESOURCE_JOB_MANAGER_TYPE_', **kwargs)
+
+
+def _provider_name_field(**kwargs):
+    from airavata.model.appcatalog.computeresource.ttypes import (
+        ProviderName as _ThriftProviderName,
+    )
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.computeresource import (  # noqa: E501
+        compute_resource_pb2,
+    )
+    return proto_enum_int_field(
+        compute_resource_pb2.ProviderName.DESCRIPTOR, _ThriftProviderName,
+        proto_prefix='PROVIDER_NAME_', **kwargs)
+
+
+def _monitor_mode_field(**kwargs):
+    from airavata.model.appcatalog.computeresource.ttypes import (
+        MonitorMode as _ThriftMonitorMode,
+    )
+    from airavata_sdk.generated.org.apache.airavata.model.appcatalog.computeresource import (  # noqa: E501
+        compute_resource_pb2,
+    )
+    return proto_enum_int_field(
+        compute_resource_pb2.MonitorMode.DESCRIPTOR, _ThriftMonitorMode,
+        name_map=_MONITOR_MODE_NAME_MAP, **kwargs)
+
+
+class ResourceJobManagerSerializer(serializers.Serializer):
+    """Proto-native serializer for the gRPC ``ResourceJobManager`` message."""
+
+    resourceJobManagerId = serializers.CharField(
+        source='resource_job_manager_id', allow_blank=True, allow_null=True,
+        required=False)
+    resourceJobManagerType = _resource_job_manager_type_field(
+        source='resource_job_manager_type', required=False, allow_null=True)
+    pushMonitoringEndpoint = serializers.CharField(
+        source='push_monitoring_endpoint', allow_blank=True, allow_null=True,
+        required=False)
+    jobManagerBinPath = serializers.CharField(
+        source='job_manager_bin_path', allow_blank=True, allow_null=True,
+        required=False)
+    jobManagerCommands = serializers.SerializerMethodField()
+    parallelismPrefix = serializers.SerializerMethodField()
+
+    def get_jobManagerCommands(self, pb):
+        from airavata.model.appcatalog.computeresource.ttypes import (
+            JobManagerCommand as _ThriftJobManagerCommand,
+        )
+        from airavata_sdk.generated.org.apache.airavata.model.appcatalog.computeresource import (  # noqa: E501
+            compute_resource_pb2,
+        )
+        return proto_enum_keyed_map_field(
+            compute_resource_pb2.JobManagerCommand.DESCRIPTOR,
+            _ThriftJobManagerCommand).to_representation(pb.job_manager_commands)
+
+    def get_parallelismPrefix(self, pb):
+        from airavata.model.appcatalog.parallelism.ttypes import (
+            ApplicationParallelismType as _ThriftParallelismType,
+        )
+        from airavata_sdk.generated.org.apache.airavata.model.parallelism import (
+            parallelism_pb2,
+        )
+        return proto_enum_keyed_map_field(
+            parallelism_pb2.ApplicationParallelismType.DESCRIPTOR,
+            _ThriftParallelismType).to_representation(pb.parallelism_prefix)
+
+
+class LocalJobSubmissionSerializer(serializers.Serializer):
+    """Proto-native serializer for the gRPC ``LOCALSubmission`` message."""
+
+    jobSubmissionInterfaceId = serializers.CharField(
+        source='job_submission_interface_id', allow_blank=True, allow_null=True,
+        required=False)
+    resourceJobManager = ResourceJobManagerSerializer(
+        source='resource_job_manager', required=False)
+    securityProtocol = _security_protocol_field(
+        source='security_protocol', required=False, allow_null=True)
+
+
+class SshJobSubmissionSerializer(serializers.Serializer):
+    """Proto-native serializer for the gRPC ``SSHJobSubmission`` message."""
+
+    jobSubmissionInterfaceId = serializers.CharField(
+        source='job_submission_interface_id', allow_blank=True, allow_null=True,
+        required=False)
+    securityProtocol = _security_protocol_field(
+        source='security_protocol', required=False, allow_null=True)
+    resourceJobManager = ResourceJobManagerSerializer(
+        source='resource_job_manager', required=False)
+    alternativeSSHHostName = serializers.CharField(
+        source='alternative_ssh_host_name', allow_blank=True, allow_null=True,
+        required=False)
+    sshPort = ProtoIntOrNoneField(source='ssh_port')
+    monitorMode = _monitor_mode_field(
+        source='monitor_mode', required=False, allow_null=True)
+    batchQueueEmailSenders = serializers.ListField(
+        source='batch_queue_email_senders', child=serializers.CharField(),
+        required=False)
+
+
+class CloudJobSubmissionSerializer(serializers.Serializer):
+    """Proto-native serializer for the gRPC ``CloudJobSubmission`` message."""
+
+    jobSubmissionInterfaceId = serializers.CharField(
+        source='job_submission_interface_id', allow_blank=True, allow_null=True,
+        required=False)
+    securityProtocol = _security_protocol_field(
+        source='security_protocol', required=False, allow_null=True)
+    nodeId = serializers.CharField(
+        source='node_id', allow_blank=True, allow_null=True, required=False)
+    executableType = serializers.CharField(
+        source='executable_type', allow_blank=True, allow_null=True,
+        required=False)
+    providerName = _provider_name_field(
+        source='provider_name', required=False, allow_null=True)
+    userAccountName = serializers.CharField(
+        source='user_account_name', allow_blank=True, allow_null=True,
+        required=False)
+
+
+class UnicoreJobSubmissionSerializer(serializers.Serializer):
+    """Proto-native serializer for the gRPC ``UnicoreJobSubmission`` message."""
+
+    jobSubmissionInterfaceId = serializers.CharField(
+        source='job_submission_interface_id', allow_blank=True, allow_null=True,
+        required=False)
+    securityProtocol = _security_protocol_field(
+        source='security_protocol', required=False, allow_null=True)
+    unicoreEndPointURL = serializers.CharField(
+        source='unicore_end_point_url', allow_blank=True, allow_null=True,
+        required=False)
+
+
+class LocalDataMovementSerializer(serializers.Serializer):
+    """Proto-native serializer for the gRPC ``LOCALDataMovement`` message."""
+
+    dataMovementInterfaceId = serializers.CharField(
+        source='data_movement_interface_id', allow_blank=True, allow_null=True,
+        required=False)
+
+
+class ScpDataMovementSerializer(serializers.Serializer):
+    """Proto-native serializer for the gRPC ``SCPDataMovement`` message."""
+
+    dataMovementInterfaceId = serializers.CharField(
+        source='data_movement_interface_id', allow_blank=True, allow_null=True,
+        required=False)
+    securityProtocol = _security_protocol_field(
+        source='security_protocol', required=False, allow_null=True)
+    alternativeSCPHostName = serializers.CharField(
+        source='alternative_scp_host_name', allow_blank=True, allow_null=True,
+        required=False)
+    sshPort = ProtoIntOrNoneField(source='ssh_port')
+
+
+class GridFtpDataMovementSerializer(serializers.Serializer):
+    """Proto-native serializer for the gRPC ``GridFTPDataMovement`` message."""
+
+    dataMovementInterfaceId = serializers.CharField(
+        source='data_movement_interface_id', allow_blank=True, allow_null=True,
+        required=False)
+    securityProtocol = _security_protocol_field(
+        source='security_protocol', required=False, allow_null=True)
+    gridFTPEndPoints = serializers.ListField(
+        source='grid_ftp_end_points', child=serializers.CharField(),
+        required=False)
 
 
 class ExperimentStatusSerializer(

--- a/airavata-django-portal/django_airavata/apps/api/views.py
+++ b/airavata-django-portal/django_airavata/apps/api/views.py
@@ -7,18 +7,7 @@ import warnings
 from datetime import datetime, timedelta
 from urllib.parse import quote
 
-from airavata.model.appcatalog.computeresource.ttypes import (
-    CloudJobSubmission,
-    LOCALSubmission,
-    SSHJobSubmission,
-    UnicoreJobSubmission
-)
 from airavata.model.application.io.ttypes import DataType
-from airavata.model.data.movement.ttypes import (
-    GridFTPDataMovement,
-    LOCALDataMovement,
-    SCPDataMovement
-)
 from airavata.model.experiment.ttypes import (
     ExperimentModel,
     ExperimentSearchFields
@@ -70,7 +59,6 @@ from . import (
     output_views,
     serializers,
     signals,
-    thrift_utils,
     tus,
     view_utils
 )
@@ -767,12 +755,11 @@ class LocalJobSubmissionView(APIView):
 
     def get(self, request, format=None):
         job_submission_id = request.query_params["id"]
-        local_job_submission = grpc_adapters.local_job_submission(
+        local_job_submission = (
             request.airavata.compute.get_local_job_submission(job_submission_id))
         return Response(
-            thrift_utils.create_serializer(
-                LOCALSubmission,
-                instance=local_job_submission).data)
+            serializers.LocalJobSubmissionSerializer(
+                local_job_submission).data)
 
 
 class CloudJobSubmissionView(APIView):
@@ -780,12 +767,10 @@ class CloudJobSubmissionView(APIView):
 
     def get(self, request, format=None):
         job_submission_id = request.query_params["id"]
-        job_submission = grpc_adapters.cloud_job_submission(
-            request.airavata.compute.get_cloud_job_submission(job_submission_id))
+        job_submission = request.airavata.compute.get_cloud_job_submission(
+            job_submission_id)
         return Response(
-            thrift_utils.create_serializer(
-                CloudJobSubmission,
-                instance=job_submission).data)
+            serializers.CloudJobSubmissionSerializer(job_submission).data)
 
 
 class SshJobSubmissionView(APIView):
@@ -793,12 +778,10 @@ class SshJobSubmissionView(APIView):
 
     def get(self, request, format=None):
         job_submission_id = request.query_params["id"]
-        job_submission = grpc_adapters.ssh_job_submission(
-            request.airavata.compute.get_ssh_job_submission(job_submission_id))
+        job_submission = request.airavata.compute.get_ssh_job_submission(
+            job_submission_id)
         return Response(
-            thrift_utils.create_serializer(
-                SSHJobSubmission,
-                instance=job_submission).data)
+            serializers.SshJobSubmissionSerializer(job_submission).data)
 
 
 class UnicoreJobSubmissionView(APIView):
@@ -806,12 +789,10 @@ class UnicoreJobSubmissionView(APIView):
 
     def get(self, request, format=None):
         job_submission_id = request.query_params["id"]
-        job_submission = grpc_adapters.unicore_job_submission(
-            request.airavata.compute.get_unicore_job_submission(job_submission_id))
+        job_submission = request.airavata.compute.get_unicore_job_submission(
+            job_submission_id)
         return Response(
-            thrift_utils.create_serializer(
-                UnicoreJobSubmission,
-                instance=job_submission).data)
+            serializers.UnicoreJobSubmissionSerializer(job_submission).data)
 
 
 class GridFtpDataMovementView(APIView):
@@ -819,12 +800,10 @@ class GridFtpDataMovementView(APIView):
 
     def get(self, request, format=None):
         data_movement_id = request.query_params["id"]
-        data_movement = grpc_adapters.grid_ftp_data_movement(
-            request.airavata.storage.get_grid_ftp_data_movement(data_movement_id))
+        data_movement = request.airavata.storage.get_grid_ftp_data_movement(
+            data_movement_id)
         return Response(
-            thrift_utils.create_serializer(
-                GridFTPDataMovement,
-                instance=data_movement).data)
+            serializers.GridFtpDataMovementSerializer(data_movement).data)
 
 
 class ScpDataMovementView(APIView):
@@ -832,12 +811,10 @@ class ScpDataMovementView(APIView):
 
     def get(self, request, format=None):
         data_movement_id = request.query_params["id"]
-        data_movement = grpc_adapters.scp_data_movement(
-            request.airavata.storage.get_scp_data_movement(data_movement_id))
+        data_movement = request.airavata.storage.get_scp_data_movement(
+            data_movement_id)
         return Response(
-            thrift_utils.create_serializer(
-                SCPDataMovement,
-                instance=data_movement).data)
+            serializers.ScpDataMovementSerializer(data_movement).data)
 
 
 class LocalDataMovementView(APIView):
@@ -845,12 +822,10 @@ class LocalDataMovementView(APIView):
 
     def get(self, request, format=None):
         data_movement_id = request.query_params["id"]
-        data_movement = grpc_adapters.local_data_movement(
-            request.airavata.storage.get_local_data_movement(data_movement_id))
+        data_movement = request.airavata.storage.get_local_data_movement(
+            data_movement_id)
         return Response(
-            thrift_utils.create_serializer(
-                LOCALDataMovement,
-                instance=data_movement).data)
+            serializers.LocalDataMovementSerializer(data_movement).data)
 
 
 class DataProductView(APIView):


### PR DESCRIPTION
Part of the Track D proto-native serializer rewrite (retire the interim Thrift-type adapter layer, family by family, REST contract byte-for-byte preserved).

## What
Replace the inline `thrift_utils.create_serializer(<ThriftType>)` rendering in the 7 admin-only per-protocol detail views with hand-written proto-native DRF serializers reading the gRPC protobuf directly: LOCAL/SSH/Cloud/Unicore job submission + LOCAL/SCP/GridFTP data movement, plus the nested `ResourceJobManager`.

- New `ProtoEnumKeyedMapField` (+ factory) renders a proto `map<int32,string>` whose int key holds a proto enum value as the `{str(Thrift enum member): value}` dict the old enum-keyed Thrift map produced (e.g. `{'JobManagerCommand.SUBMISSION': 'sbatch'}`).
- SecurityProtocol/ResourceJobManagerType/ProviderName render as Thrift ints via prefix-aligned `proto_enum_int_field`; MonitorMode via its divergent `name_map` (proto `MONITOR_FORK`/`MONITOR_LOCAL` → Thrift `FORK`/`LOCAL`).
- Repoint the 7 views to pass protobuf straight to the new serializers — drops the `grpc_adapters` per-protocol funcs (+ `_resource_job_manager`, `_enum_keyed_map`, `_MONITOR_MODE`) and the now-unused Thrift imports; views.py no longer imports `thrift_utils`.

## Validation
- Byte-for-byte (all 7 models incl. the two enum-keyed maps, MonitorMode divergence, nested ResourceJobManager, ProviderName null) vs the old adapter+thrift_utils `.data`.
- `manage.py check` green; api test failures unchanged vs `origin/main`.