### PR TITLE
Remove dead portal Python code

### DIFF
--- a/airavata-django-portal/django_airavata/apps/admin/templates/admin/compute_resource.html
+++ b/airavata-django-portal/django_airavata/apps/admin/templates/admin/compute_resource.html
@@ -1,8 +1,0 @@
-{% extends "admin/admin_base.html"%}
-{% load static %}
-{% block scripts %}
-   <script>
-    window.airavataDashboardName='group_resource_preference_dashboard';
-   </script>
-    {{ block.super }}
-{% endblock %}


### PR DESCRIPTION
Three unreferenced bits of Python in the Django portal:
- `api/web.py`: unused `_cls_or`/`_cls_and`/`_cls_invert` — superseded by the inline monkeypatch lambdas that set `OperationHolderMixin.__or__`/`__and__`/`__invert__` (0 callers).
- `admin/views.py`: `compute_resource` view + its `admin/compute_resource.html` template — the view has no URL route anywhere.
- `api/helpers.py`: unused `_can_read` (0 callers); the live permission check is `_can_write`.

## Test plan
- Grep: 0 callers/routes for each removed symbol.
- `py_compile` of the 3 edited modules passes; portal restarts to HTTP 200 (Django imports all views/urls on startup).