### PR TITLE
Remove unused npm dependencies from groups and auth apps

### DIFF
--- a/airavata-django-portal/django_airavata/apps/auth/package.json
+++ b/airavata-django-portal/django_airavata/apps/auth/package.json
@@ -12,10 +12,7 @@
   },
   "dependencies": {
     "django-airavata-api": "link:../api/",
-    "django-airavata-common-ui": "link:../../static/common/",
-    "vue": "^2.7.16",
-    "vuelidate": "^0.7.6",
-    "vuex": "^3.6.2"
+    "django-airavata-common-ui": "link:../../static/common/"
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",

--- a/airavata-django-portal/django_airavata/apps/auth/yarn.lock
+++ b/airavata-django-portal/django_airavata/apps/auth/yarn.lock
@@ -2019,16 +2019,6 @@ vue@^2.7.16:
     "@vue/compiler-sfc" "2.7.16"
     csstype "^3.1.0"
 
-vuelidate@^0.7.6:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/vuelidate/-/vuelidate-0.7.6.tgz#84100c13b943470660d0416642845cd2a1edf4b2"
-  integrity sha512-suzIuet1jGcyZ4oUSW8J27R2tNrJ9cIfklAh63EbAkFjE380iv97BAiIeolRYoB9bF9usBXCu4BxftWN1Dkn3g==
-
-vuex@^3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.6.2.tgz#236bc086a870c3ae79946f107f16de59d5895e71"
-  integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
-
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"

--- a/airavata-django-portal/django_airavata/apps/groups/package.json
+++ b/airavata-django-portal/django_airavata/apps/groups/package.json
@@ -11,10 +11,8 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "bootstrap": "^4.0.0-beta.2",
     "django-airavata-api": "link:../api",
     "django-airavata-common-ui": "link:../../static/common",
-    "moment": "^2.18.1",
     "vue": "^2.7.16"
   },
   "devDependencies": {

--- a/airavata-django-portal/django_airavata/apps/groups/yarn.lock
+++ b/airavata-django-portal/django_airavata/apps/groups/yarn.lock
@@ -762,7 +762,7 @@ bootstrap-vue@^2.21.2:
     portal-vue "^2.1.7"
     vue-functional-data-merge "^3.1.0"
 
-"bootstrap@>=4.5.3 <5.0.0", bootstrap@^4.0.0-beta.2, bootstrap@^4.3.1:
+"bootstrap@>=4.5.3 <5.0.0", bootstrap@^4.3.1:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.0.tgz#97b9f29ac98f98dfa43bf7468262d84392552fd7"
   integrity sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==
@@ -1489,7 +1489,7 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-moment@^2.18.1, moment@^2.24.0:
+moment@^2.24.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
- **groups**: drop `bootstrap` and `moment` (0 imports in groups; the bootstrap styling + moment date handling come through the linked `django-airavata-common-ui` workspace package).
- **auth**: drop `vue`, `vuelidate`, `vuex` (auth is Keycloak-hosted with no Vue pages — its build (`node build-stats.mjs`) emits an empty `webpack-stats.json`).

`yarn.lock` regenerated for both apps via `yarn remove`.

## Test plan
- Grep: 0 imports of the removed deps in each app's source.
- auth `yarn run build` passes post-removal; groups deps are unimported so its bundle is unaffected.
- yarn.lock diffs are focused (removed-dep entries only).