### PR TITLE
Drop url-parse; extract the filename directly in DataProduct

### DIFF
--- a/airavata-django-portal/django_airavata/apps/api/package.json
+++ b/airavata-django-portal/django_airavata/apps/api/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "stacktrace-js": "^2.0.0",
-    "url-parse": "^1.4.3",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/airavata-django-portal/django_airavata/apps/api/static/django_airavata_api/js/models/DataProduct.js
+++ b/airavata-django-portal/django_airavata/apps/api/static/django_airavata_api/js/models/DataProduct.js
@@ -1,8 +1,6 @@
 import BaseModel from "./BaseModel";
 import DataReplicaLocation from "./DataReplicaLocation";
 
-import URL from "url-parse";
-
 const FIELDS = [
   "product_uri",
   "gateway_id",
@@ -48,9 +46,8 @@ export default class DataProduct extends BaseModel {
 
   get filename() {
     if (this.replica_locations && this.replica_locations.length > 0) {
-      const firstReplicaLocation = this.replica_locations[0];
-      const fileURL = new URL(firstReplicaLocation.file_path);
-      const filenameMatch = FILENAME_REGEX.exec(fileURL.pathname);
+      // file_path is a file:// URI or plain path; the last path segment is the filename.
+      const filenameMatch = FILENAME_REGEX.exec(this.replica_locations[0].file_path);
       if (filenameMatch) {
         return filenameMatch[0];
       }

--- a/airavata-django-portal/django_airavata/apps/api/yarn.lock
+++ b/airavata-django-portal/django_airavata/apps/api/yarn.lock
@@ -2160,11 +2160,6 @@ punycode@^2.1.0, punycode@^2.3.1:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-querystringify@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz"
-  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
-
 reflect.getprototypeof@^1.0.10, reflect.getprototypeof@^1.0.9:
   version "1.0.10"
   resolved "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz"
@@ -2195,11 +2190,6 @@ regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
-
-requires-port@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
-  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -2770,14 +2760,6 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
-
-url-parse@^1.4.3:
-  version "1.5.10"
-  resolved "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz"
-  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
-  dependencies:
-    querystringify "^2.1.1"
-    requires-port "^1.0.0"
 
 uuid@^3.3.2:
   version "3.4.0"


### PR DESCRIPTION
`DataProduct.filename` parsed the replica `file_path` with `url-parse` only to read `.pathname` before applying `FILENAME_REGEX` (`/[^/]+$/`) for the last path segment. Native `URL` **throws** on the real `file://user@host:port/...` replica paths (and on bare paths), and the regex already yields the last segment from any of those forms — so the url-parse step was redundant.

Apply the regex to `file_path` directly and drop the `url-parse` dependency (maintenance-mode, with a history of high-severity advisories).

## Test plan
- Verified `FILENAME_REGEX` returns the correct filename for `file://user@host:22/.../Echo.stdout`, `file:///...`, and bare `/path` forms.
- url-parse removed from api package.json + yarn.lock; no remaining references in source.