### PR TITLE
Return a clean response when settings_local download is blocked in DEBUG

### DIFF
--- a/airavata-django-portal/django_airavata/apps/auth/views.py
+++ b/airavata-django-portal/django_airavata/apps/auth/views.py
@@ -7,7 +7,12 @@ import requests
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
-from django.http import FileResponse, HttpResponseForbidden, JsonResponse
+from django.http import (
+    FileResponse,
+    HttpResponseBadRequest,
+    HttpResponseForbidden,
+    JsonResponse,
+)
 from django.shortcuts import redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -236,7 +241,7 @@ def download_settings_local(request):
         raise PermissionDenied()
 
     if settings.DEBUG:
-        raise Exception(
+        return HttpResponseBadRequest(
             "Downloading a settings_local.py file isn't allowed in DEBUG mode."
         )
 


### PR DESCRIPTION
`download_settings_local` raised a bare `Exception` when the portal runs in `DEBUG` mode, which Django renders as an unhandled 500 with a full stack trace. The restriction is intentional (the local-dev settings download is a production-portal helper), but it should degrade gracefully — this returns `HttpResponseBadRequest` with the same message instead.

Test plan: `GET /auth/settings-local/` as a gateway admin in DEBUG now returns HTTP 400 with the message (previously a 500 stack trace). Verified live.