### PR TITLE
Don't fetch a parser on the data-parser create page

### DIFF
--- a/airavata-django-portal/django_airavata/apps/auth/views.py
+++ b/airavata-django-portal/django_airavata/apps/auth/views.py
@@ -7,7 +7,12 @@ import requests
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
-from django.http import FileResponse, HttpResponseForbidden, JsonResponse
+from django.http import (
+    FileResponse,
+    HttpResponseBadRequest,
+    HttpResponseForbidden,
+    JsonResponse,
+)
 from django.shortcuts import redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -236,7 +241,7 @@ def download_settings_local(request):
         raise PermissionDenied()
 
     if settings.DEBUG:
-        raise Exception(
+        return HttpResponseBadRequest(
             "Downloading a settings_local.py file isn't allowed in DEBUG mode."
         )
 

--- a/airavata-django-portal/django_airavata/apps/dataparsers/static/django_airavata_dataparsers/js/containers/ParserEditContainer.vue
+++ b/airavata-django-portal/django_airavata/apps/dataparsers/static/django_airavata_dataparsers/js/containers/ParserEditContainer.vue
@@ -10,14 +10,14 @@
 <script>
 import ParserEditor from "../parser-components/ParserEditor.vue";
 
-import { services } from "django-airavata-api";
+import { models, services } from "django-airavata-api";
 
 export default {
   name: "parser-edit-container",
   props: {
     parserId: {
       type: String,
-      required: true,
+      default: null,
     },
   },
   data() {
@@ -38,9 +38,15 @@ export default {
   },
   computed: {},
   mounted: function () {
-    services.ParserService.retrieve({ lookup: this.parserId }).then(
-      (parser) => (this.parser = parser)
-    );
+    // No parserId means this is the "create parser" page: start from an empty
+    // parser instead of fetching (retrieving a null id errors server-side).
+    if (this.parserId) {
+      services.ParserService.retrieve({ lookup: this.parserId }).then(
+        (parser) => (this.parser = parser)
+      );
+    } else {
+      this.parser = new models.Parser();
+    }
   },
 };
 </script>


### PR DESCRIPTION
`ParserEditContainer.mounted()` always called `ParserService.retrieve({ lookup: this.parserId })`, but the create page (`/dataparsers/create/`) mounts the container with no `parserId` (the entry point defaults it to `null` and only sets it from a non-empty `data-parser-id`). The request therefore went out as `GET /api/parsers/null/` and the server returned `Error retrieving parser with id: null: No Parser Info entry exists for null`.

Fetch only when a `parserId` is present; otherwise start from an empty `models.Parser()` so the editor renders for a new parser. Also relaxes the `parserId` prop from `required` to `default: null` (the create page legitimately passes none).

Test plan: `/dataparsers/edit/<id>/` still loads the existing parser; `/dataparsers/create/` renders an empty editor without issuing a null parser fetch.