### PR TITLE
Export Parser/ParserInput/ParserOutput from the api models namespace

### DIFF
--- a/airavata-django-portal/django_airavata/apps/api/static/django_airavata_api/js/index.js
+++ b/airavata-django-portal/django_airavata/apps/api/static/django_airavata_api/js/index.js
@@ -37,6 +37,9 @@ import Notification from "./models/Notification";
 import NotificationPriority from "./models/NotificationPriority";
 import OutputDataObjectType from "./models/OutputDataObjectType";
 import ParallelismType from "./models/ParallelismType";
+import Parser from "./models/Parser";
+import ParserInput from "./models/ParserInput";
+import ParserOutput from "./models/ParserOutput";
 import Project from "./models/Project";
 import ResourcePermissionType from "./models/ResourcePermissionType";
 import SetEnvPaths from "./models/SetEnvPaths";
@@ -104,6 +107,9 @@ const models = {
   NotificationPriority,
   OutputDataObjectType,
   ParallelismType,
+  Parser,
+  ParserInput,
+  ParserOutput,
   Project,
   ResourcePermissionType,
   ResourceType,


### PR DESCRIPTION
The parser models existed and were used internally (`service_config` `modelClass: Parser`) but were never added to the public `models` export, so `models.Parser` was `undefined`. `ParserEditor` referenced it only as a prop `type` (which silently degrades to `undefined` with no error), hiding the gap. Constructing `new models.Parser()` for the data-parser create page surfaced it as "models.Parser is not a constructor". This exports `Parser`, `ParserInput`, and `ParserOutput` alongside the other models.

Test plan: `/dataparsers/create/` constructs an empty `models.Parser()` and renders the editor without error.