### PR TITLE
fix(portal): experiment editor — kill 'Leave site?' popup, fix experiment creation, token-derived account link

### DIFF
--- a/airavata-django-portal/django_airavata/apps/workspace/static/django_airavata_workspace/js/components/experiment/ComputationalResourceSchedulingEditor.vue
+++ b/airavata-django-portal/django_airavata/apps/workspace/static/django_airavata_workspace/js/components/experiment/ComputationalResourceSchedulingEditor.vue
@@ -50,22 +50,18 @@
 
 <script>
 import QueueSettingsEditor from "./QueueSettingsEditor.vue";
-import {
-  errors,
-  models,
-  services,
-  utils as apiUtils,
-} from "django-airavata-api";
+import { errors, services, utils as apiUtils } from "django-airavata-api";
 import { mixins, utils } from "django-airavata-common-ui";
 import { NATIVE_SELECT_CLASS } from "../../lib/utils";
 
 export default {
   name: "computational-resource-scheduling-editor",
+  // VModelMixin supplies the `modelValue` prop and the `data` working copy, and
+  // emits `update:modelValue` for the parent's v-model. (This component used to
+  // also declare a Vue 2 `value` prop and emit `input`, which the parent ignored
+  // — and `this.value` was undefined under Vue 3, crashing data() below.)
   mixins: [mixins.VModelMixin],
   props: {
-    value: {
-      type: models.ComputationalResourceSchedulingModel,
-    },
     appModuleId: {
       type: String,
       required: true,
@@ -80,7 +76,7 @@ export default {
       computeResources: {},
       applicationDeployments: [],
       selectedGroupResourceProfileData: null,
-      resourceHostId: this.value.resource_host_id,
+      resourceHostId: this.modelValue.resource_host_id,
       invalidQueueSettings: false,
       workspacePreferences: null,
     };
@@ -233,7 +229,7 @@ export default {
       // whenever it changes
       this.localComputationalResourceScheduling.resource_host_id =
         this.resourceHostId;
-      this.$emit("input", this.data);
+      this.$emit("update:modelValue", this.data);
     },
     queueSettingsValidityChanged(valid) {
       this.invalidQueueSettings = !valid;
@@ -248,7 +244,7 @@ export default {
     },
     emitValueChanged: function () {
       this.validate();
-      this.$emit("input", this.localComputationalResourceScheduling);
+      this.$emit("update:modelValue", this.localComputationalResourceScheduling);
     },
     getValidationFeedback: function (properties) {
       return utils.getProperty(this.validation, properties);

--- a/airavata-django-portal/django_airavata/apps/workspace/static/django_airavata_workspace/js/components/experiment/GroupResourceProfileSelector.vue
+++ b/airavata-django-portal/django_airavata/apps/workspace/static/django_airavata_workspace/js/components/experiment/GroupResourceProfileSelector.vue
@@ -29,13 +29,18 @@ import { NATIVE_SELECT_CLASS } from "../../lib/utils";
 export default {
   name: "group-resource-profile-selector",
   props: {
-    value: {
+    // Vue 3 v-model: the parent binds with `v-model`, which passes `modelValue`
+    // and listens for `update:modelValue`. (Was the Vue 2 `value`/`input` pair,
+    // which the parent's v-model silently ignored — so the auto-selected
+    // allocation never propagated and experiments were created with a null
+    // group_resource_profile_id, 500ing server-side.)
+    modelValue: {
       type: String,
     },
   },
   data() {
     return {
-      groupResourceProfileId: this.value,
+      groupResourceProfileId: this.modelValue,
       groupResourceProfiles: [],
       workspacePreferences: null,
     };
@@ -78,7 +83,7 @@ export default {
         (groupResourceProfiles) => {
           this.groupResourceProfiles = groupResourceProfiles;
           if (
-            (!this.value ||
+            (!this.modelValue ||
               !this.selectedValueInGroupResourceProfileList(
                 groupResourceProfiles,
               )) &&
@@ -105,13 +110,13 @@ export default {
     },
     emitValueChanged: function () {
       this.validate();
-      this.$emit("input", this.groupResourceProfileId);
+      this.$emit("update:modelValue", this.groupResourceProfileId);
     },
     selectedValueInGroupResourceProfileList(groupResourceProfiles) {
       return (
         groupResourceProfiles
           .map((grp) => grp.group_resource_profile_id)
-          .indexOf(this.value) >= 0
+          .indexOf(this.modelValue) >= 0
       );
     },
     validate() {

--- a/airavata-django-portal/django_airavata/apps/workspace/static/django_airavata_workspace/js/components/experiment/QueueSettingsEditor.vue
+++ b/airavata-django-portal/django_airavata/apps/workspace/static/django_airavata_workspace/js/components/experiment/QueueSettingsEditor.vue
@@ -261,11 +261,11 @@ import { NATIVE_SELECT_CLASS } from "../../lib/utils";
 export default {
   name: "queue-settings-editor",
   components: { Info, Lock, LockOpen, X },
+  // VModelMixin supplies the `modelValue` prop and the `data` working copy and
+  // emits `update:modelValue`; the parent binds with v-model. (Was a leftover
+  // Vue 2 `value` prop — undefined under Vue 3, crashing mounted() below.)
   mixins: [mixins.VModelMixin],
   props: {
-    value: {
-      type: models.ComputationalResourceSchedulingModel,
-    },
     appDeploymentId: {
       type: String,
       required: true,
@@ -586,7 +586,7 @@ export default {
         this.setDefaultQueue();
       }
     },
-    value: {
+    modelValue: {
       // Rerun validation whenever the queue settings change, which can from
       // outside the component, for example when a queue settings calculator
       // provides values
@@ -608,7 +608,7 @@ export default {
     this.loadAppDeploymentQueues().then(() => {
       // For brand new queue settings (no queueName specified) load the default
       // queue and its default values and apply them
-      if (!this.value.queue_name) {
+      if (!this.modelValue.queue_name) {
         this.setDefaultQueue();
       }
     });

--- a/airavata-django-portal/django_airavata/apps/workspace/static/django_airavata_workspace/js/utils/urls.js
+++ b/airavata-django-portal/django_airavata/apps/workspace/static/django_airavata_workspace/js/utils/urls.js
@@ -1,3 +1,5 @@
+import { utils } from "django-airavata-common-ui";
+
 export default {
   editExperiment(experiment) {
     return (
@@ -7,13 +9,13 @@ export default {
     );
   },
   navigateToEditExperiment(experiment) {
-    window.location.assign(this.editExperiment(experiment));
+    utils.navigateTo(this.editExperiment(experiment));
   },
   experimentsList() {
     return "/workspace/experiments";
   },
   navigateToExperimentsList() {
-    window.location.assign(this.experimentsList());
+    utils.navigateTo(this.experimentsList());
   },
   viewExperiment(experiment, { launching = false } = {}) {
     return (
@@ -24,7 +26,7 @@ export default {
     );
   },
   navigateToViewExperiment(experiment, { launching = false } = {}) {
-    window.location.assign(
+    utils.navigateTo(
       this.viewExperiment(experiment, { launching: launching }),
     );
   },
@@ -36,7 +38,7 @@ export default {
     );
   },
   navigateToCreateExperiment(appModule) {
-    window.location.assign(this.createExperiment(appModule));
+    utils.navigateTo(this.createExperiment(appModule));
   },
   editProject(project) {
     return (
@@ -47,7 +49,7 @@ export default {
     return "/workspace/projects";
   },
   navigateToProjectsList() {
-    window.location.assign(this.projectsList());
+    utils.navigateTo(this.projectsList());
   },
   viewGroupResourceProfile(groupResourceProfile) {
     return `/admin/group-resource-profiles/${encodeURIComponent(

--- a/airavata-django-portal/django_airavata/context_processors.py
+++ b/airavata-django-portal/django_airavata/context_processors.py
@@ -222,6 +222,25 @@ def _safe_reverse(name):
         return "#"
 
 
+def _account_console_url(request):
+    """Keycloak account console URL for the signed-in user's own profile.
+
+    Generated from the ``iss`` (issuer) claim of the user's own access token —
+    i.e. the realm they actually authenticated against, which is exactly the
+    ``issuer`` advertised by that realm's OIDC discovery (``.well-known``)
+    document. The account console lives at ``<issuer>/account/`` by Keycloak
+    convention (the discovery document itself exposes no account endpoint). This
+    keeps the link correct per-user/per-realm without depending on a separately
+    configured URL. Falls back to the configured ``KEYCLOAK_ACCOUNT_CONSOLE_URL``
+    setting if the token carries no issuer.
+    """
+    claims = getattr(getattr(request, "user", None), "claims", None) or {}
+    issuer = claims.get("iss")
+    if issuer:
+        return issuer.rstrip("/") + "/account/"
+    return getattr(settings, "KEYCLOAK_ACCOUNT_CONSOLE_URL", "")
+
+
 def shell_data(request):
     """Assemble the page-shell data the Vue app shell (AppShell.vue) renders.
 
@@ -302,7 +321,7 @@ def shell_data(request):
             "username": getattr(request.user, "username", ""),
             "email": getattr(request.user, "email", ""),
         }
-        data["accountUrl"] = getattr(settings, "KEYCLOAK_ACCOUNT_CONSOLE_URL", "")
+        data["accountUrl"] = _account_console_url(request)
         data["logoutUrl"] = _safe_reverse("django_airavata_auth:logout")
         notifications = get_notifications(request)
         data["notices"] = json.loads(notifications.get("notifications") or "[]")

--- a/airavata-django-portal/django_airavata/static/common/js/components/UnsavedChangesGuard.vue
+++ b/airavata-django-portal/django_airavata/static/common/js/components/UnsavedChangesGuard.vue
@@ -3,6 +3,8 @@
 </template>
 
 <script>
+import { isIntentionalNavigation } from "../utils";
+
 export default {
   name: "unsaved-changes-guard",
   props: {
@@ -19,7 +21,9 @@ export default {
   },
   methods: {
     onBeforeUnload(event) {
-      if (this.dirty) {
+      // Don't warn when the portal itself is navigating (e.g. after a save).
+      // Only genuinely accidental leaves with unsaved edits should prompt.
+      if (this.dirty && !isIntentionalNavigation()) {
         event.preventDefault();
         // Have to return a message for some browsers in order to trigger popup
         // asking user if they want to leave the page. I don't think any browser

--- a/airavata-django-portal/django_airavata/static/common/js/components/ui/button/Button.vue
+++ b/airavata-django-portal/django_airavata/static/common/js/components/ui/button/Button.vue
@@ -13,6 +13,13 @@ const props = defineProps({
   },
   asChild: { type: Boolean, required: false },
   as: { type: null, required: false, default: "button" },
+  // Default to a non-submitting button, matching the prior Bootstrap-Vue
+  // <b-button> default. A native <button> defaults to type="submit", so inside a
+  // <form> a bare <Button @click="…"> would also submit the form on click —
+  // triggering a full-page navigation and the browser's "Leave site?" unsaved-
+  // changes guard before the click handler runs. Pass type="submit" explicitly
+  // for real submit buttons.
+  type: { type: String, required: false, default: "button" },
 });
 </script>
 
@@ -23,6 +30,7 @@ const props = defineProps({
     :data-size="size"
     :as="as"
     :as-child="asChild"
+    :type="as === 'button' && !asChild ? type : undefined"
     :class="cn(buttonVariants({ variant, size }), props.class)"
   >
     <slot />

--- a/airavata-django-portal/django_airavata/static/common/js/utils.js
+++ b/airavata-django-portal/django_airavata/static/common/js/utils.js
@@ -24,3 +24,22 @@ export const dateFormatters = {
     timeZoneName: "short",
   }),
 };
+
+// Tracks app-initiated (intentional) navigations so UnsavedChangesGuard does not
+// pop the native "Leave site?" dialog when the portal itself sends the user to
+// another page (e.g. after Save / Save and Launch). The guard should still warn
+// on genuinely accidental leaves (closing the tab, browser back/forward, editing
+// the URL bar, following an unrelated link) while there are unsaved edits.
+let intentionalNavigation = false;
+
+export function isIntentionalNavigation() {
+  return intentionalNavigation;
+}
+
+// Send the browser to `url` as an intentional, app-initiated navigation. Use this
+// instead of window.location.assign for in-portal navigations (e.g. redirecting
+// after a successful save) so the unsaved-changes guard stays silent.
+export function navigateTo(url) {
+  intentionalNavigation = true;
+  window.location.assign(url);
+}


### PR DESCRIPTION
Fixes a cluster of experiment-editor regressions from the Vue 3 / shadcn migration, plus a related account-console link improvement. Verified end-to-end in the dev portal: create + Save and Launch an Echo experiment now succeeds with no 'Leave site?' popup and the job runs (Status LAUNCHED).

## 1. 'Leave site?' popup on action buttons
Root cause: shadcn-vue's `<Button>` renders a native `<button>`, which defaults to `type="submit"`. Inside a `<form>`, clicking 'Save' / 'Save and Launch' therefore **submitted the form** (a full-page navigation) on top of the `@click` handler, firing the browser's unsaved-changes `beforeunload` guard before the click handler could run. (Bootstrap-Vue's `<b-button>` defaulted to `type="button"`, so the code never set it explicitly.)
- Default `Button` to `type="button"` (explicit `type="submit"` still honored; the 3 native-submit forms are unaffected).
- Also added an intentional-navigation latch (`utils.navigateTo` / `isIntentionalNavigation`) the `UnsavedChangesGuard` consults, so app-initiated redirects after a save never prompt while accidental leaves still do. Workspace `urls.js` routes through it.

## 2. Experiment creation 500 ('crd is null')
The allocation/scheduling editors were never migrated to Vue 3 v-model — the parent binds `v-model` (`modelValue`/`update:modelValue`) but the children used the Vue 2 `value`/`input` pair:
- `GroupResourceProfileSelector`: the auto-selected profile emitted `input` (ignored) → `group_resource_profile_id` stayed null → server NPE; and the scheduling editor (gated on it) never rendered.
- `ComputationalResourceSchedulingEditor` / `QueueSettingsEditor`: used `VModelMixin` yet still read `this.value` (undefined under Vue 3) → crashed once rendered.
Switched all three to `modelValue` + `update:modelValue`. Allocation, compute resource, and queue settings now bind; the form validates; create + launch succeed.

## 3. Account console link from the user's token
User-menu 'User Settings' now derives `<issuer>/account/` from the `iss` claim of the signed-in user's access token (the realm's OIDC discovery issuer), instead of a separate setting. Falls back to `KEYCLOAK_ACCOUNT_CONSOLE_URL`. (The account console's own HTTP 500 was a Keycloak default-theme misconfig, fixed in apache/airavata#693.)

## Test plan
- `build_js.sh` + `lint_js.sh` clean; `ruff check` clean.
- Live: Save and Launch an Echo experiment → no popup, experiment created, navigates to summary, Status LAUNCHED with the SLURM job ACTIVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)