### PR TITLE
fix(admin): confine editor action bars, fix list field editors, drop no-op stats tab

### DIFF
--- a/airavata-django-portal/django_airavata/apps/admin/static/django_airavata_admin/src/components/admin/group_resource_preferences/ComputePreference.vue
+++ b/airavata-django-portal/django_airavata/apps/admin/static/django_airavata_admin/src/components/admin/group_resource_preferences/ComputePreference.vue
@@ -186,7 +186,7 @@
         </CardContent>
       </Card>
       <div
-        class="bg-background fixed inset-x-0 bottom-0 flex gap-2 border-t p-4 shadow-md"
+        class="bg-background fixed bottom-0 left-64 right-0 flex justify-end gap-2 border-t p-4 shadow-md"
       >
         <Button
           variant="default"

--- a/airavata-django-portal/django_airavata/apps/admin/static/django_airavata_admin/src/components/admin/group_resource_preferences/ComputeResourceReservationList.vue
+++ b/airavata-django-portal/django_airavata/apps/admin/static/django_airavata_admin/src/components/admin/group_resource_preferences/ComputeResourceReservationList.vue
@@ -112,8 +112,8 @@
                 <Card>
                   <CardContent>
                     <compute-resource-reservation-editor
-                      :value="item"
-                      @input="updatedReservation"
+                      :model-value="item"
+                      @update:model-value="updatedReservation"
                       :queues="queues"
                       @valid="removeInvalidReservation(item.key)"
                       @invalid="recordInvalidReservation(item.key)"

--- a/airavata-django-portal/django_airavata/apps/admin/static/django_airavata_admin/src/components/admin/group_resource_preferences/GroupComputeResourcePreference.vue
+++ b/airavata-django-portal/django_airavata/apps/admin/static/django_airavata_admin/src/components/admin/group_resource_preferences/GroupComputeResourcePreference.vue
@@ -148,7 +148,7 @@
         </template>
       </list-layout>
       <div
-        class="bg-background fixed inset-x-0 bottom-0 flex gap-2 border-t p-4 shadow-md"
+        class="bg-background fixed bottom-0 left-64 right-0 flex justify-end gap-2 border-t p-4 shadow-md"
       >
         <Button
           variant="default"

--- a/airavata-django-portal/django_airavata/apps/admin/static/django_airavata_admin/src/components/applications/ApplicationEditorContainer.vue
+++ b/airavata-django-portal/django_airavata/apps/admin/static/django_airavata_admin/src/components/applications/ApplicationEditorContainer.vue
@@ -80,7 +80,7 @@
       />
     </div>
     <div
-      class="bg-background fixed inset-x-0 bottom-0 flex gap-2 border-t p-4 shadow-md"
+      class="bg-background fixed bottom-0 left-64 right-0 flex justify-end gap-2 border-t p-4 shadow-md"
     >
       <Button
         variant="default"

--- a/airavata-django-portal/django_airavata/apps/admin/static/django_airavata_admin/src/components/applications/ApplicationInterfaceEditor.vue
+++ b/airavata-django-portal/django_airavata/apps/admin/static/django_airavata_admin/src/components/applications/ApplicationInterfaceEditor.vue
@@ -103,10 +103,10 @@
       >
         <template #item="{ element: input }">
           <application-input-field-editor
-            :value="input"
+            :model-value="input"
             :focus="input.key === focusApplicationInputKey"
             :collapse="collapseApplicationInputs"
-            @input="updatedInput"
+            @update:model-value="updatedInput"
             @delete="deleteInput(input)"
             :readonly="readonly"
           />
@@ -126,10 +126,10 @@
       <h2 class="mb-4 text-lg font-semibold">Output Fields</h2>
       <application-output-field-editor
         v-for="output in data.application_outputs"
-        :value="output"
+        :model-value="output"
         :key="output.key"
         :focus="output.key === focusApplicationOutputKey"
-        @input="updatedOutput"
+        @update:model-value="updatedOutput"
         @delete="deleteOutput(output)"
         :readonly="readonly"
       />

--- a/airavata-django-portal/django_airavata/apps/admin/static/django_airavata_admin/src/components/gatewayprofile/StoragePreferenceList.vue
+++ b/airavata-django-portal/django_airavata/apps/admin/static/django_airavata_admin/src/components/gatewayprofile/StoragePreferenceList.vue
@@ -105,8 +105,8 @@
                 <Card>
                   <CardContent>
                     <storage-preference-editor
-                      :value="item"
-                      @input="updatedStoragePreference"
+                      :model-value="item"
+                      @update:model-value="updatedStoragePreference"
                       :default-credential-store-token="
                         defaultCredentialStoreToken
                       "

--- a/airavata-django-portal/django_airavata/apps/admin/static/django_airavata_admin/src/components/statistics/ExperimentStatisticsContainer.vue
+++ b/airavata-django-portal/django_airavata/apps/admin/static/django_airavata_admin/src/components/statistics/ExperimentStatisticsContainer.vue
@@ -4,8 +4,9 @@
     subtitle="Gateway experiment activity over time."
   >
     <Tabs v-model="activeTab" ref="tabs" class="space-y-4">
-      <TabsList>
-        <TabsTrigger value="statistics">Statistics</TabsTrigger>
+      <!-- Only show the tab bar once experiment-detail tabs are open; the lone
+           "Statistics" pill was a no-op (the statistics view is the default). -->
+      <TabsList v-if="experimentDetailTabs.length > 0">
         <TabsTrigger
           v-for="experimentTab in experimentDetailTabs"
           :key="experimentTab.experiment.experiment_id"

--- a/airavata-django-portal/django_airavata/apps/admin/static/django_airavata_admin/src/components/users/ExtendedUserProfileContainer.vue
+++ b/airavata-django-portal/django_airavata/apps/admin/static/django_airavata_admin/src/components/users/ExtendedUserProfileContainer.vue
@@ -21,8 +21,8 @@
       </transition-group>
       <div ref="bottom" />
     </div>
-    <div class="bg-background fixed inset-x-0 bottom-0 border-t p-4 shadow-md">
-      <div class="flex">
+    <div class="bg-background fixed bottom-0 left-64 right-0 border-t p-4 shadow-md">
+      <div class="flex justify-end gap-2">
         <DropdownMenu>
           <DropdownMenuTrigger as-child>
             <Button variant="outline" :disabled="!isGatewayAdmin"


### PR DESCRIPTION
Three admin-UI fixes (all verified live).

## 1. Bottom action bars overlapped the sidebar
The Save/Delete/Cancel/Add bars in the application, compute-preference, group-compute-preference, and extended-user-profile editors used `fixed inset-x-0 bottom-0`, spanning the full viewport and sitting **on top of the w-64 left navbar**. Confined them to the content area (`left-64 right-0`) and right-aligned the buttons (`justify-end`).

## 2. Application input/output field editors rendered empty
On the application **Interface** tab, adding (or viewing) an input/output field showed an **empty box** with no config UI. Root cause: the parent (`ApplicationInterfaceEditor`) bound the `VModelMixin` child editors with the Vue 2 `:value`/`@input` pair, so `modelValue` was `undefined` → the working copy never initialized → the template threw on `data.name`/`data.key`. Switched the list bindings to `:model-value`/`@update:model-value`. Same fix applied to the other list editors with the identical pattern: **ComputeResourceReservationList** and **StoragePreferenceList**. (`ApplicationDeploymentEditor` already used `v-model` correctly.)

## 3. No-op "Statistics" tab
Removed the lone `Statistics` tab pill on the Experiment Statistics page; the tab bar now renders only once experiment-detail tabs are open (the statistics view is the default).

## Test plan
- `lint_js.sh` clean; admin build clean.
- Verified live: the 4 editors' action bars sit in the content area, right-aligned, clear of the navbar; adding an application input renders the full field config (Name/Type/Initial Value/Required/etc.); the stats page no longer shows the lone pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)